### PR TITLE
Pr wfmdata variable size

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -13,46 +13,46 @@
 # -------- BASIC MODULES --------
 
 # --- basic siriuspy modules
-siriuspy/siriuspy/* @gu1lhermelp @xresende @anacso17 @fernandohds564 @liulin-lili
+/siriuspy/siriuspy/* @gu1lhermelp @xresende @anacso17 @fernandohds564 @liulin-lili
 
 
 # -------- SUBPACKAGES --------
 
 # --- bsmp subpackage
-siriuspy/siriuspy/bsmp/ @gu1lhermelp @xresende @fernandohds564
+/siriuspy/siriuspy/bsmp/ @gu1lhermelp @xresende @fernandohds564
 
 # --- csdevice subpackage
-siriuspy/siriuspy/csdevice/ @gu1lhermelp @xresende @fernandohds564
+/siriuspy/siriuspy/csdevice/ @gu1lhermelp @xresende @fernandohds564
 
 # --- diagnostics subpackage
-siriuspy/siriuspy/diagnostics/ @fernandohds564 @xresende
+/siriuspy/siriuspy/diagnostics/ @fernandohds564 @xresende
 
 # --- epics subpackage
-siriuspy/siriuspy/epics/ @gu1lhermelp @xresende @fernandohds564
+/siriuspy/siriuspy/epics/ @gu1lhermelp @xresende @fernandohds564
 
 # --- magnet subpackage
-siriuspy/siriuspy/magnet/ @gu1lhermelp @xresende @fernandohds564
+/siriuspy/siriuspy/magnet/ @gu1lhermelp @xresende @fernandohds564
 
 # --- namesys subpackage
-siriuspy/siriuspy/namesys/ @gu1lhermelp @xresende @fernandohds564 @anacso17
+/siriuspy/siriuspy/namesys/ @gu1lhermelp @xresende @fernandohds564 @anacso17
 
 # --- pwrsupply subpackage
-siriuspy/siriuspy/pwrsupply/ @gu1lhermelp @xresende @fernandohds564 @anacso17
+/siriuspy/siriuspy/pwrsupply/ @gu1lhermelp @xresende @fernandohds564 @anacso17
 
 # --- ramp subpackage
-siriuspy/siriuspy/ramp/ @gu1lhermelp @xresende @fernandohds564 @liulin-lili
+/siriuspy/siriuspy/ramp/ @gu1lhermelp @xresende @fernandohds564 @liulin-lili
 
 # --- servccdb subpackage
-siriuspy/siriuspy/servccdb/ @xresende
+/siriuspy/siriuspy/servccdb/ @xresende
 
 # --- servconf subpackage
-siriuspy/siriuspy/servconf/ @gu1lhermelp @xresende @liulin-lili
+/siriuspy/siriuspy/servconf/ @gu1lhermelp @xresende @liulin-lili
 
 # --- servname subpackage
-siriuspy/siriuspy/servname/ @xresende
+/siriuspy/siriuspy/servname/ @xresende
 
 # --- servweb subpackage
-siriuspy/siriuspy/servweb/ @xresende @liulin-lili
+/siriuspy/siriuspy/servweb/ @xresende @liulin-lili
 
 # --- timesys subpackage
-siriuspy/siriuspy/timesys/ @fernandohds564 @xresende
+/siriuspy/siriuspy/timesys/ @fernandohds564 @xresende

--- a/siriuspy/siriuspy/csdevice/pwrsupply.py
+++ b/siriuspy/siriuspy/csdevice/pwrsupply.py
@@ -5,7 +5,7 @@ from collections import namedtuple as _namedtuple
 from siriuspy.csdevice.enumtypes import EnumTypes as _et
 from siriuspy.search import PSSearch as _PSSearch
 from siriuspy.search import MASearch as _MASearch
-default_wfmsize = 4000
+max_wfmsize = 4000
 default_wfmlabels = _et.enums('PSWfmLabelsTyp')
 # default_intlklabels = _et.enums('PSIntlkLabelsTyp')
 default_ps_current_precision = 4
@@ -145,12 +145,12 @@ def get_common_ps_propty_database():
         #                 'value': 0},
         # 'WfmLoad-Sts': {'type': 'enum', 'enums': default_wfmlabels,
         #                 'value': 0},
-        'WfmData-SP': {'type': 'float', 'count': default_wfmsize,
+        'WfmData-SP': {'type': 'float', 'count': max_wfmsize,
                        'prec': default_ps_current_precision,
-                       'value': [0.0 for datum in range(default_wfmsize)]},
-        'WfmData-RB': {'type': 'float', 'count': default_wfmsize,
+                       'value': [0.0 for datum in range(max_wfmsize)]},
+        'WfmData-RB': {'type': 'float', 'count': max_wfmsize,
                        'prec': default_ps_current_precision,
-                       'value': [0.0 for datum in range(default_wfmsize)]},
+                       'value': [0.0 for datum in range(max_wfmsize)]},
         # 'WfmSave-Cmd': {'type': 'int', 'value': 0},
         'Current-SP': {'type': 'float', 'value': 0.0,
                        'prec': default_ps_current_precision},

--- a/siriuspy/siriuspy/pwrsupply/controller.py
+++ b/siriuspy/siriuspy/pwrsupply/controller.py
@@ -4,6 +4,7 @@ import time as _time
 import random as _random
 from siriuspy import util as _util
 from siriuspy.bsmp import Const as _ack
+from siriuspy.csdevice.pwrsupply import max_wfmsize as _max_wfmsize
 from siriuspy.csdevice.pwrsupply import Const as _PSConst
 from siriuspy.csdevice.pwrsupply import ps_opmode as _ps_opmode
 from siriuspy.pwrsupply.bsmp import Const as _BSMPConst
@@ -287,6 +288,10 @@ class ControllerIOC(PSCommInterface):
         return value
 
     def _set_wfmdata(self, value):
+        if isinstance(value, (int, float)):
+            value = [value, ]
+        elif len(value) > _max_wfmsize:
+            value = value[:_max_wfmsize]
         self._wfmdata = value[:]
         self._serial_comm.set_wfmdata(self._ID_device, self._wfmdata)
         return value

--- a/siriuspy/siriuspy/pwrsupply/controller.py
+++ b/siriuspy/siriuspy/pwrsupply/controller.py
@@ -61,6 +61,9 @@ class ControllerIOC(PSCommInterface):
 
     """
 
+    _WAIT_TURN_ON_OFF = 0.3  # [s]
+    _WAIT_RESET_INTLCKS = 0.1  # [s]
+
     # conversion dict from PS fields to DSP properties for read method.
     _read_field2func = {
         'Version-Cte': '_get_firmware_version',
@@ -93,7 +96,7 @@ class ControllerIOC(PSCommInterface):
         self._ID_device = ID_device
         self._ps_db = ps_database
         # self._opmode = _PSConst.OpMode.SlowRef
-        self._wfmdata = [v for v in self._ps_db['WfmData-SP']['value']]
+        # self._wfmdata = [v for v in self._ps_db['WfmData-SP']['value']]
 
         # ps_status = self._get_ps_status()
 
@@ -121,13 +124,13 @@ class ControllerIOC(PSCommInterface):
     def cmd_turn_on(self):
         """Turn power supply on."""
         r = self._bsmp_run_function(ID_function=_BSMPConst.turn_on)
-        _time.sleep(0.3)  # Eduardo-CON said it is necessary!
+        _time.sleep(ControllerIOC._WAIT_TURN_ON_OFF)
         return r
 
     def cmd_turn_off(self):
         """Turn power supply off."""
         ret = self._bsmp_run_function(ID_function=_BSMPConst.turn_off)
-        _time.sleep(0.3)  # Eduardo-CON said it is necessary!
+        _time.sleep(ControllerIOC._WAIT_TURN_ON_OFF)
         return ret
 
     def cmd_open_loop(self):
@@ -142,7 +145,7 @@ class ControllerIOC(PSCommInterface):
     def cmd_reset_interlocks(self):
         """Reset interlocks."""
         r = self._bsmp_run_function(_BSMPConst.reset_interlocks)
-        _time.sleep(0.1)  # Eduardo-CON said it is necessary!
+        _time.sleep(ControllerIOC._WAIT_RESET_INTLCKS)
         return r
 
     def cmd_set_slowref(self, setpoint):
@@ -181,7 +184,8 @@ class ControllerIOC(PSCommInterface):
         return self._serial_comm.get_connected(self._ID_device)
 
     def _get_wfmdata(self):
-        return self._wfmdata
+        wfmdata = self._serial_comm.get_wfmdata(self._ID_device)
+        return wfmdata[:]
 
     def _get_wfmindex(self):
         return self._serial_comm.sync_pulse_count

--- a/siriuspy/siriuspy/pwrsupply/model.py
+++ b/siriuspy/siriuspy/pwrsupply/model.py
@@ -199,7 +199,10 @@ class PowerSupply(_PSCommInterface):
         return self._controller.write('WfmLabel-SP', value)
 
     def _set_wfmdata(self, value):
-        value = [v for v in range(min(len(value, _max_wfmsize)))]
+        if isinstance(value, (int, float)):
+            value = [value, ]
+        elif len(value) > _max_wfmsize:
+            value = value[:_max_wfmsize]
         self._setpoints['WfmData-SP']['value'] = value
         return self._controller.write('WfmData-SP', value)
 

--- a/siriuspy/siriuspy/pwrsupply/model.py
+++ b/siriuspy/siriuspy/pwrsupply/model.py
@@ -10,6 +10,7 @@ from epics import PV as _PV
 
 from siriuspy.namesys import SiriusPVName as _SiriusPVName
 from siriuspy.envars import vaca_prefix as _VACA_PREFIX
+from siriuspy.csdevice.pwrsupply import max_wfmsize as _max_wfmsize
 from siriuspy.factory import NormalizerFactory as _NormalizerFactory
 from siriuspy.epics import connection_timeout as _connection_timeout
 from siriuspy.epics.computed_pv import QueueThread as _QueueThread
@@ -160,7 +161,8 @@ class PowerSupply(_PSCommInterface):
             keyvalue['value'] = db['WfmLabel-SP']['value']
         elif field == 'WfmData-SP':
             keyvalue['func'] = self._set_wfmdata
-            keyvalue['value'] = [v for v in db['WfmData-SP']['value']]
+            # keyvalue['value'] = [v for v in db['WfmData-SP']['value']]
+            keyvalue['value'] = self._controller.read('WfmData-RB')
         elif field == 'Abort-Cmd':
             keyvalue['func'] = self._abort
             keyvalue['value'] = db['Abort-Cmd']['value']
@@ -197,16 +199,8 @@ class PowerSupply(_PSCommInterface):
         return self._controller.write('WfmLabel-SP', value)
 
     def _set_wfmdata(self, value):
-        # make sure wfmdata has the correct length
-        n = len(self._setpoints['WfmData-SP']['value'])
-        if isinstance(value, (int, float)):
-            self._setpoints['WfmData-SP']['value'][0] = value
-        elif len(value) == n:
-            self._setpoints['WfmData-SP']['value'] = value
-        else:
-            for i in range(min(len(value), n)):
-                self._setpoints['WfmData-SP']['value'][i] = value[i]
-        value = self._setpoints['WfmData-SP']['value']
+        value = [v for v in range(min(len(value, _max_wfmsize)))]
+        self._setpoints['WfmData-SP']['value'] = value
         return self._controller.write('WfmData-SP', value)
 
     def _abort(self, value):

--- a/siriuspy/siriuspy/ramp/waveform.py
+++ b/siriuspy/siriuspy/ramp/waveform.py
@@ -1,7 +1,7 @@
 """Waveform Set Module."""
 
 import numpy as _np
-from siriuspy.csdevice.pwrsupply import default_wfmsize as _default_wfmsize
+from siriuspy.csdevice.pwrsupply import max_wfmsize as _max_wfmsize
 
 
 _np.seterr(all='ignore')
@@ -10,7 +10,7 @@ _np.seterr(all='ignore')
 class Waveform():
     """Waveform parameter class."""
 
-    wfmsize = _default_wfmsize
+    wfmsize = _max_wfmsize
 
     def __init__(self,
                  scale=None,

--- a/siriuspy/siriuspy/servconf/conf_types.py
+++ b/siriuspy/siriuspy/servconf/conf_types.py
@@ -60,8 +60,8 @@ def _init_config_types_dict():
 
 
 def _recursive_check(ref_value, value):
-    # TODO: should be allow float - int automatic castings ?
-    # TODO: this shoukd prob. be generalized to accomodate length-varying
+    # TODO: should we allow float - int automatic castings ?
+    # TODO: this should prob. be generalized to accomodate length-varying
     # lists/arrays (WfmData, for example)
     if type(ref_value) != type(value):
         return False

--- a/siriuspy/siriuspy/servconf/conf_types.py
+++ b/siriuspy/siriuspy/servconf/conf_types.py
@@ -60,7 +60,9 @@ def _init_config_types_dict():
 
 
 def _recursive_check(ref_value, value):
-    # should be allow float - int automatic castings ?
+    # TODO: should be allow float - int automatic castings ?
+    # TODO: this shoukd prob. be generalized to accomodate length-varying
+    # lists/arrays (WfmData, for example)
     if type(ref_value) != type(value):
         return False
     if type(ref_value) == dict:

--- a/siriuspy/siriuspy/servconf/types/rmp_bo_ps.py
+++ b/siriuspy/siriuspy/servconf/types/rmp_bo_ps.py
@@ -1,9 +1,10 @@
 """Booster ramp configuration definition."""
 import copy as _copy
-from siriuspy.csdevice.pwrsupply import max_wfmsize as \
-    _max_wfmsize
+from siriuspy.csdevice.pwrsupply import max_wfmsize as _max_wfmsize
 
 
+# TODO: this ref_wfm can be changed to a smaller size list after config type
+# comparison is generalized.
 _ref_wfm_array = [0.0 for _ in range(_max_wfmsize)]
 
 

--- a/siriuspy/siriuspy/servconf/types/rmp_bo_ps.py
+++ b/siriuspy/siriuspy/servconf/types/rmp_bo_ps.py
@@ -1,10 +1,10 @@
 """Booster ramp configuration definition."""
 import copy as _copy
-from siriuspy.csdevice.pwrsupply import default_wfmsize as \
-    _default_wfmsize
+from siriuspy.csdevice.pwrsupply import max_wfmsize as \
+    _max_wfmsize
 
 
-_ref_wfm_array = [0.0 for _ in range(_default_wfmsize)]
+_ref_wfm_array = [0.0 for _ in range(_max_wfmsize)]
 
 
 def get_dict():

--- a/siriuspy/tests/csdevice/test_pwrsupply.py
+++ b/siriuspy/tests/csdevice/test_pwrsupply.py
@@ -12,7 +12,7 @@ _mock_flag = True
 
 
 public_interface = (
-    'default_wfmsize',
+    'max_wfmsize',
     'default_wfmlabels',
     'default_ps_current_precision',
     'default_pu_current_precision',


### PR DESCRIPTION
- change pwrsupply classes to allow for length-varying wfmdata setpoints.
- configuration comparisons in servconf will have to be generalized!