### PR TITLE
Pr generalize ps types

### DIFF
--- a/siriuspy/siriuspy/csdevice/pwrsupply.py
+++ b/siriuspy/siriuspy/csdevice/pwrsupply.py
@@ -29,26 +29,52 @@ ps_pwrstate_sts = ('Off', 'On')
 ps_opmode = ('SlowRef', 'SlowRefSync', 'FastRef', 'RmpWfm', 'MigWfm', 'Cycle')
 ps_cmdack = ('OK', 'Local', 'PCHost', 'Interlocked', 'UDC_locked',
              'DSP_TimeOut', 'DSP_Busy', 'Invalid',)
-ps_soft_interlock = ('Overtemperature on module', 'Reserved',
-                     'Reserved', 'Reserved',
-                     'Reserved', 'Reserved', 'Reserved', 'Reserved',
-                     'Reserved', 'Reserved', 'Reserved', 'Reserved',
-                     'Reserved', 'Reserved', 'Reserved', 'Reserved',
-                     'Reserved', 'Reserved', 'Reserved', 'Reserved',
-                     'Reserved', 'Reserved', 'Reserved', 'Reserved',
-                     'Reserved', 'Reserved', 'Reserved', 'Reserved',
-                     'Reserved', 'Reserved', 'Reserved', 'Reserved',
-                     )
-ps_hard_interlock = ('Overvoltage on load', 'Overvoltage on DC-Link',
-                     'Undervoltage on DC-Link', 'DC-Link input relay fail',
-                     'DC-Link input fuse fail', 'Fail on module drivers',
-                     'Reserved', 'Reserved',
-                     'Reserved', 'Reserved', 'Reserved', 'Reserved',
-                     'Reserved', 'Reserved', 'Reserved', 'Reserved',
-                     'Reserved', 'Reserved', 'Reserved', 'Reserved',
-                     'Reserved', 'Reserved', 'Reserved', 'Reserved',
-                     'Reserved', 'Reserved', 'Reserved', 'Reserved',
-                     'Reserved', 'Reserved', 'Reserved', 'Reserved',)
+
+ps_soft_interlock_FBP = (
+    'Overtemperature on module', 'Reserved', 'Reserved', 'Reserved',
+    'Reserved', 'Reserved', 'Reserved', 'Reserved',
+    'Reserved', 'Reserved', 'Reserved', 'Reserved',
+    'Reserved', 'Reserved', 'Reserved', 'Reserved',
+    'Reserved', 'Reserved', 'Reserved', 'Reserved',
+    'Reserved', 'Reserved', 'Reserved', 'Reserved',
+    'Reserved', 'Reserved', 'Reserved', 'Reserved',
+    'Reserved', 'Reserved', 'Reserved', 'Reserved',
+)
+ps_hard_interlock_FBP = (
+    'Overvoltage on load', 'Overvoltage on DC-Link',
+    'Undervoltage on DC-Link', 'DC-Link input relay fail',
+    'DC-Link input fuse fail', 'Fail on module drivers',
+    'Reserved', 'Reserved',
+    'Reserved', 'Reserved', 'Reserved', 'Reserved',
+    'Reserved', 'Reserved', 'Reserved', 'Reserved',
+    'Reserved', 'Reserved', 'Reserved', 'Reserved',
+    'Reserved', 'Reserved', 'Reserved', 'Reserved',
+    'Reserved', 'Reserved', 'Reserved', 'Reserved',
+    'Reserved', 'Reserved', 'Reserved', 'Reserved',
+)
+ps_soft_interlock_FBP_DCLink = (
+    'Reserved', 'Reserved', 'Reserved', 'Reserved',
+    'Reserved', 'Reserved', 'Reserved', 'Reserved',
+    'Reserved', 'Reserved', 'Reserved', 'Reserved',
+    'Reserved', 'Reserved', 'Reserved', 'Reserved',
+    'Reserved', 'Reserved', 'Reserved', 'Reserved',
+    'Reserved', 'Reserved', 'Reserved', 'Reserved',
+    'Reserved', 'Reserved', 'Reserved', 'Reserved',
+    'Reserved', 'Reserved', 'Reserved', 'Reserved',
+)
+ps_hard_interlock_FBP_DCLink = (
+    'Falha na fonte 1', 'Falha na fonte 2',
+    'Falha na fonte 3', 'Sensor de fumaça',
+    'Interlock externo', 'Sobre-tensão na fonte 1'
+    'Sobre-tensão na fonte 2', 'Sobre-tensão na fonte 3',
+    'Sub-tensão na fonte 1', 'Sub-tensão na fonte 2',
+    'Sub-tensão na fonte 3', 'Reserved',
+    'Reserved', 'Reserved', 'Reserved', 'Reserved',
+    'Reserved', 'Reserved', 'Reserved', 'Reserved',
+    'Reserved', 'Reserved', 'Reserved', 'Reserved',
+    'Reserved', 'Reserved', 'Reserved', 'Reserved',
+    'Reserved', 'Reserved', 'Reserved', 'Reserved',
+)
 
 # --- power supply constants definition class ---
 
@@ -116,12 +142,12 @@ def get_common_propty_database():
                              'value': _et.idx.Off},
         'IntlkSoft-Mon':    {'type': 'int',    'value': 0},
         'IntlkHard-Mon':    {'type': 'int',    'value': 0},
-        'IntlkSoftLabels-Cte':  {'type': 'string',
-                                 'count': len(ps_soft_interlock),
-                                 'value': ps_soft_interlock},
-        'IntlkHardLabels-Cte':  {'type': 'string',
-                                 'count': len(ps_hard_interlock),
-                                 'value': ps_hard_interlock},
+        # 'IntlkSoftLabels-Cte':  {'type': 'string',
+        #                          'count': len(ps_soft_interlock),
+        #                          'value': ps_soft_interlock},
+        # 'IntlkHardLabels-Cte':  {'type': 'string',
+        #                          'count': len(ps_hard_interlock),
+        #                          'value': ps_hard_interlock},
         'Reset-Cmd': {'type': 'int', 'value': 0},
     }
     return db
@@ -160,6 +186,12 @@ def get_common_ps_propty_database():
                            'prec': default_ps_current_precision},
         'Current-Mon': {'type': 'float',  'value': 0.0,
                         'prec': default_ps_current_precision},
+        'IntlkSoftLabels-Cte':  {'type': 'string',
+                                 'count': len(ps_soft_interlock_FBP),
+                                 'value': ps_soft_interlock_FBP},
+        'IntlkHardLabels-Cte':  {'type': 'string',
+                                 'count': len(ps_hard_interlock_FBP),
+                                 'value': ps_hard_interlock_FBP},
     }
     db.update(db_ps)
     return db

--- a/siriuspy/siriuspy/csdevice/pwrsupply.py
+++ b/siriuspy/siriuspy/csdevice/pwrsupply.py
@@ -140,8 +140,6 @@ def get_common_propty_database():
                              'value': _et.idx.Off},
         'PwrState-Sts':     {'type': 'enum', 'enums': ps_pwrstate_sts,
                              'value': _et.idx.Off},
-        'IntlkSoft-Mon':    {'type': 'int',    'value': 0},
-        'IntlkHard-Mon':    {'type': 'int',    'value': 0},
         # 'IntlkSoftLabels-Cte':  {'type': 'string',
         #                          'count': len(ps_soft_interlock),
         #                          'value': ps_soft_interlock},
@@ -153,7 +151,7 @@ def get_common_propty_database():
     return db
 
 
-def get_common_ps_propty_database():
+def get_ps_FBP_propty_database():
     """Return database of commun to all pwrsupply PVs."""
     db = get_common_propty_database()
     db_ps = {
@@ -186,6 +184,8 @@ def get_common_ps_propty_database():
                            'prec': default_ps_current_precision},
         'Current-Mon': {'type': 'float',  'value': 0.0,
                         'prec': default_ps_current_precision},
+        'IntlkSoft-Mon':    {'type': 'int',    'value': 0},
+        'IntlkHard-Mon':    {'type': 'int',    'value': 0},
         'IntlkSoftLabels-Cte':  {'type': 'string',
                                  'count': len(ps_soft_interlock_FBP),
                                  'value': ps_soft_interlock_FBP},
@@ -217,7 +217,7 @@ def get_common_pu_propty_database():
 
 def get_ps_propty_database(pstype):
     """Return property database of a LNLS power supply type device."""
-    propty_db = get_common_ps_propty_database()
+    propty_db = get_ps_FBP_propty_database()
     signals_lims = ('Current-SP', 'Current-RB',
                     'CurrentRef-Mon', 'Current-Mon', )
     signals_unit = signals_lims + ('WfmData-SP', 'WfmData-RB')

--- a/siriuspy/siriuspy/csdevice/pwrsupply.py
+++ b/siriuspy/siriuspy/csdevice/pwrsupply.py
@@ -261,7 +261,7 @@ def get_ma_propty_database(maname):
     current_alarm = ('Current-SP', 'Current-RB',
                      'CurrentRef-Mon', 'Current-Mon', )
     current_pvs = current_alarm  # + ('WfmData-SP', 'WfmData-RB')
-    propty_db = get_common_ps_propty_database()
+    propty_db = get_ps_FBP_propty_database()
     unit = _MASearch.get_splims_unit(ispulsed=False)
     magfunc_dict = _MASearch.conv_maname_2_magfunc(maname)
     db = {}

--- a/siriuspy/siriuspy/pwrsupply/bsmp.py
+++ b/siriuspy/siriuspy/pwrsupply/bsmp.py
@@ -14,8 +14,10 @@ from siriuspy.csdevice.pwrsupply import ps_states as _ps_states
 from siriuspy.csdevice.pwrsupply import ps_pwrstate_sel as _ps_pwrstate_sel
 from siriuspy.csdevice.pwrsupply import ps_opmode as _ps_opmode
 from siriuspy.csdevice.pwrsupply import Const as _PSConst
-from siriuspy.csdevice.pwrsupply import ps_soft_interlock as _ps_soft_interlock
-from siriuspy.csdevice.pwrsupply import ps_hard_interlock as _ps_hard_interlock
+from siriuspy.csdevice.pwrsupply import ps_soft_interlock_FBP as \
+    _ps_soft_interlock_FBP
+from siriuspy.csdevice.pwrsupply import ps_hard_interlock_FBP as \
+    _ps_hard_interlock_FBP
 
 
 class Const:
@@ -271,7 +273,7 @@ class _InterlockSoft(_Interlock):
     """Power supply soft iterlocks."""
 
     def __init__(self):
-        self._labels = _ps_soft_interlock
+        self._labels = _ps_soft_interlock_FBP
         self._init()
 
 
@@ -279,7 +281,7 @@ class _InterlockHard(_Interlock):
     """Power supply hard iterlocks."""
 
     def __init__(self):
-        self._labels = _ps_hard_interlock
+        self._labels = _ps_hard_interlock_FBP
         self._init()
 
 

--- a/siriuspy/siriuspy/pwrsupply/controller.py
+++ b/siriuspy/siriuspy/pwrsupply/controller.py
@@ -57,8 +57,9 @@ class PSCommInterface:
 class ControllerIOC(PSCommInterface):
     """ControllerIOC class.
 
-    This class implements
-
+        This class implements methods and attributes to interact with power
+    supply controllers (ControllerPS) through the serial line (SeriaConn).
+    It can be used with any kind of power supply (any value of psmodel).
     """
 
     # conversion dict from PS fields to DSP properties for read method.
@@ -304,6 +305,8 @@ class PSState:
     power supplies, as defined by its list of BSMP variables.
     """
 
+    # TODO: should this class be moved to bsmp.py module?
+
     def __init__(self, variables):
         """Init method."""
         self._state = {}
@@ -343,7 +346,12 @@ class PSState:
 
 
 class ControllerPSSim:
-    """Simulator of power supply controller."""
+    """Simulator of power supply controller.
+
+        This class implements simulation of power supply controllers. These
+    controllers respond to BSMP commands from the IOC controller
+    (ControllerIOC) sent through the serial line.
+    """
 
     _I_LOAD_FLUCTUATION_RMS = 0.01  # [A]
     # _I_LOAD_FLUCTUATION_RMS = 0.0000  # [A]

--- a/siriuspy/siriuspy/pwrsupply/data.py
+++ b/siriuspy/siriuspy/pwrsupply/data.py
@@ -31,7 +31,11 @@ class PSData:
         if self._ispulsed:
             self._propty_database = _get_pu_propty_database(self._pstype)
         else:
-            self._propty_database = _get_ps_propty_database(self._pstype)
+            if self._psmodel == 'FBP':
+                self._propty_database = _get_ps_propty_database(self._pstype)
+            else:
+                raise ValueError(
+                    'DB for psmodel {} not implemented!'.format(self._psmodel))
 
     @property
     def psname(self):

--- a/siriuspy/siriuspy/pwrsupply/data.py
+++ b/siriuspy/siriuspy/pwrsupply/data.py
@@ -31,6 +31,7 @@ class PSData:
         if self._ispulsed:
             self._propty_database = _get_pu_propty_database(self._pstype)
         else:
+            # self._propty_database = _get_ps_propty_database(self._pstype)
             if self._psmodel == 'FBP':
                 self._propty_database = _get_ps_propty_database(self._pstype)
             else:

--- a/siriuspy/siriuspy/pwrsupply/model.py
+++ b/siriuspy/siriuspy/pwrsupply/model.py
@@ -1,11 +1,10 @@
 """Define Power Supply classes."""
 
 import re as _re
-from threading import Thread as _Thread
-from threading import Lock as _Lock
 import time as _time
 import numpy as _np
-
+from threading import Thread as _Thread
+from threading import Lock as _Lock
 from epics import PV as _PV
 
 from siriuspy.namesys import SiriusPVName as _SiriusPVName
@@ -24,8 +23,9 @@ from siriuspy.pwrsupply import sync as _sync
 class PowerSupply(_PSCommInterface):
     """Abstract control-system power supply class.
 
-        Objects of this are used to interact with power supplies in the
-    control-system using the implemented PSCommInterface.
+        Objects of this class are used to interact with power supplies in the
+    control-system using the implemented PSCommInterface. This class should
+    work for any psmodel type.
     """
 
     CONNECTED = 'CONNECTED'
@@ -302,16 +302,7 @@ class PowerSupply(_PSCommInterface):
 class PSEpics(_PSCommInterface):
     """Power supply with Epics communication."""
 
-    # Should we merge this base class into MAEpics?
-
-    # valid_fields = ('Current-SP', 'Current-RB', 'CurrentRef-Mon',
-    #                 'Current-Mon', 'PwrState-Sel', 'PwrState-Sts',
-    #                 'OpMode-Sel', 'OpMode-Sts',
-    #                 'Energy-SP', 'Energy-RB', 'EnergyRef-Mon', 'Energy-Mon',
-    #                 'KL-SP', 'KL-RB', 'KLRef-Mon', 'KL-Mon',
-    #                 'SL-SP', 'SL-RB', 'SLRef-Mon', 'SL-Mon',
-    #                 'Kick-SP', 'Kick-RB', 'KickRef-Mon', 'Kick-Mon',
-    #                 'Reset-Cmd', 'Abort-Cmd')
+    # TODO: should we merge this base class into MAEpics?
 
     def __init__(self, psname, fields=None, use_vaca=True):
         """Create epics PVs and expose them through public controller API."""

--- a/siriuspy/tests/csdevice/test_pwrsupply.py
+++ b/siriuspy/tests/csdevice/test_pwrsupply.py
@@ -25,8 +25,10 @@ public_interface = (
     'ps_pwrstate_sts',
     'ps_opmode',
     'ps_cmdack',
-    'ps_soft_interlock',
-    'ps_hard_interlock',
+    'ps_soft_interlock_FBP',
+    'ps_hard_interlock_FBP',
+    'ps_soft_interlock_FBP_DCLink',
+    'ps_hard_interlock_FBP_DCLink',
 
     'Const',
 

--- a/siriuspy/tests/csdevice/test_pwrsupply.py
+++ b/siriuspy/tests/csdevice/test_pwrsupply.py
@@ -35,7 +35,7 @@ public_interface = (
     'get_ps_current_unit',
     'get_pu_current_unit',
     'get_common_propty_database',
-    'get_common_ps_propty_database',
+    'get_ps_FBP_propty_database',
     'get_common_pu_propty_database',
     'get_ps_propty_database',
     'get_pu_propty_database',
@@ -151,7 +151,7 @@ class TestPwrSupply(unittest.TestCase):
 
     def test_common_ps_propty_database(self):
         """Test common_ps_propty_database."""
-        db = pwrsupply.get_common_ps_propty_database()
+        db = pwrsupply.get_ps_FBP_propty_database()
         self.assertIsInstance(db, dict)
         for prop in db:
             self.assertIsInstance(db[prop], dict)

--- a/siriuspy/tests/pwrsupply/test_data.py
+++ b/siriuspy/tests/pwrsupply/test_data.py
@@ -67,6 +67,7 @@ class TestPSDataProperties(unittest.TestCase):
             self.properties['splims_unit']
         self.search_mock.conv_psname_2_excdata.return_value = \
             self.properties['excdata']
+        self.search_mock.conv_psname_2_psmodel.return_value = 'FBP'
 
         self.db_mock.return_value = self.db
 
@@ -153,6 +154,7 @@ class TestPSDataDb(unittest.TestCase):
 
         self.search_mock.get_psnames.return_value = [self.psname, self.puname]
         self.search_mock.conv_psname_2_pstype.return_value = self.pstype
+        self.search_mock.conv_psname_2_psmodel.return_value = 'FBP'
 
     def test_ps_db(self):
         """Test ps db is called when a ps is passed."""


### PR DESCRIPTION
- initial steps to generalize set of classes used in PS and MA IOCs so that they can be used for any kind of power supplies (FBP, FAP, etc)
