### PR TITLE
Pr fix master real ps

### DIFF
--- a/siriuspy/siriuspy/pwrsupply/bsmp.py
+++ b/siriuspy/siriuspy/pwrsupply/bsmp.py
@@ -574,7 +574,7 @@ class BSMPMasterSlave(_BSMPResponse, StreamChecksum):
         return ID_cmd, value
 
     def cmd_0x13(self, ID_receiver, ID_group):
-        """Respond SBMP variable group."""
+        """Respond SBMP variable group read command."""
         # query power supply
         query = [chr(ID_receiver), '\x12', '\x00', '\x01', chr(ID_group)]
         query = BSMPMasterSlave.includeChecksum(query)
@@ -609,17 +609,18 @@ class BSMPMasterSlave(_BSMPResponse, StreamChecksum):
             value[Const.firmware_version] = version
             i += 128
             # ps_soft_interlocks
-            value[Const.ps_soft_interlocks] = \
-                data[i] + (data[i+1] << 8) + \
+            datum = data[i] + (data[i+1] << 8) + \
                 (data[i+2] << 16) + (data[i+3] << 24)
+            value[Const.ps_soft_interlocks] = datum
             i += 4
             # ps_hard_interlocks
-            value[Const.ps_hard_interlocks] = \
-                data[i] + (data[i+1] << 8) + \
+            datum = data[i] + (data[i+1] << 8) + \
                 (data[i+2] << 16) + (data[i+3] << 24)
+            value[Const.ps_hard_interlocks] = datum
             i += 4
             # i_load
-            value[Const.i_load] = _struct.unpack("<f", bytes(data[i:i+4]))[0]
+            datum = _struct.unpack("<f", bytes(data[i:i+4]))[0]
+            value[Const.i_load] = datum
             i += 4
         else:
             raise ValueError('Invalid group ID!')

--- a/siriuspy/siriuspy/pwrsupply/bsmp.py
+++ b/siriuspy/siriuspy/pwrsupply/bsmp.py
@@ -342,8 +342,11 @@ class Status:
     def pwrstate(status, label=False):
         """Return PS powerstate."""
         state = Status.state(status, label=False)
-        index = _PSConst.PwrState.Off if state == _PSConst.States.Off else \
-            _PSConst.PwrState.On
+        if state in (_PSConst.States.Off,
+                     _PSConst.States.Interlock):
+            index = _PSConst.PwrState.Off
+        else:
+            index = _PSConst.PwrState.On
         return _ps_pwrstate_sel[index] if label else index
 
     @staticmethod

--- a/siriuspy/siriuspy/pwrsupply/controller.py
+++ b/siriuspy/siriuspy/pwrsupply/controller.py
@@ -105,14 +105,12 @@ class ControllerIOC(PSCommInterface):
         # reset interlocks
         self.cmd_reset_interlocks()
 
+        # --- initializations ---
+        # (it was decided that IOC will only read status from PS controller)
         # turn ps on and implicitly close control loop
-        # self.pwrstate = _PSConst.PwrState.On
-        # self._pwrstate = _Status.pwrstate(ps_status)
-
+        # self._set_pwrstate(_PSConst.PwrState.On)
         # set opmode do SlowRef
-        # self.opmode = _PSConst.OpMode.SlowRef
-        # self._opmode = _Status.opmode(ps_status)
-
+        # self._set_opmode(_PSConst.OpMode.SlowRef)
         # set reference current to zero
         # self.cmd_set_slowref(0.0)
 

--- a/siriuspy/siriuspy/pwrsupply/pru.py
+++ b/siriuspy/siriuspy/pwrsupply/pru.py
@@ -349,7 +349,7 @@ class SerialComm(_BSMPQuery):
         self.put(ID_device=slave.ID_device, ID_cmd=0x32, kwargs=kwargs)
 
         # create group of all variables in slave.
-        IDs_variable = tuple(self.variables.keys())
+        IDs_variable = sorted(tuple(self.variables.keys()))
         kwargs = {'ID_group': _BSMPConst.group_id,
                   'IDs_variable': IDs_variable}
         self.put(ID_device=slave.ID_device, ID_cmd=0x30, kwargs=kwargs)

--- a/siriuspy/siriuspy/pwrsupply/pru.py
+++ b/siriuspy/siriuspy/pwrsupply/pru.py
@@ -271,8 +271,11 @@ class SerialComm(_BSMPQuery):
         self._queue.put((ID_device, ID_cmd, kwargs))
 
     def get_variable(self, ID_device, ID_variable):
-        """Return a BSMP variable."""
-        return self._states[ID_device][ID_variable]
+        """Return a BSMP variable value."""
+        value = self._states[ID_device][ID_variable]
+        # if ID_variable == _BSMPConst.i_load:
+        #     print(value)
+        return value
 
     def _process_queue(self):
         """Process queue."""
@@ -310,7 +313,7 @@ class SerialComm(_BSMPQuery):
     def _process_load(self, ID_device, ID_cmd, load):
         if ID_cmd == 0x12:
             for variable, value in load.items():
-                # if variable == 27:
+                # if variable == _BSMPConst.i_load:
                 #     print(value)
                 self._states[ID_device][variable] = value
             return 0


### PR DESCRIPTION
- Initially I thought there was a bug in the latest master branch, since the PS IOC was not working in the test bench. 
- Latter, we realized that the PS controller was not responding because of a bug in its firmware triggered when the IOC sent BSMP commands for a PS ID that was not being used. This probably happened at some point last week, when we changed the beagle-bone mapping file;
- Gabriel updated the PS controller with a new firmware which fixes this vulnerability.
- In meantime , a potential bug related to the BSMP variable group creation was fixed in <code>pru.py</code>