### PR TITLE
Corrected translation op mode in FBP_BSMPSim

### DIFF
--- a/siriuspy/siriuspy/pwrsupply/controller.py
+++ b/siriuspy/siriuspy/pwrsupply/controller.py
@@ -144,6 +144,8 @@ class FBP_BSMPSim(_BSMPSim):
         elif func_id == _c.F_SELECT_OP_MODE:  # Change state
             # Verify if ps is on
             if self._is_on():
+                psc_status = _PSCStatus(input_val)
+                input_val = psc_status.ioc_opmode
                 self._state = self._states[input_val]
                 self._state.select_op_mode(self._variables)
         elif func_id == _c.F_RESET_INTERLOCKS:  # Change state


### PR DESCRIPTION
Used `PSCStatus` to get the right value for the op mode in the `execute_function` method of the `FBP_BSMPSim`.