### PR TITLE
Small changes in csdevice

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ pip-log.txt
 pip-delete-this-directory.txt
 
 # Unit test / coverage reports
+.pytest_cache/
 htmlcov/
 .tox/
 .coverage

--- a/siriuspy/siriuspy/csdevice/__init__.py
+++ b/siriuspy/siriuspy/csdevice/__init__.py
@@ -1,5 +1,5 @@
 """CSDEVICE - control-system device subpackage.
 
-This subpackage contains modules with information adn data on devices
+This subpackage contains modules with information and data on devices
 control system properties.
 """

--- a/siriuspy/siriuspy/csdevice/const.py
+++ b/siriuspy/siriuspy/csdevice/const.py
@@ -26,24 +26,7 @@ class Const:
     @staticmethod
     def add_field(field_name, values):
         """Add field with constant values in const namespace."""
-        for i in range(len(values)):
-            if not Const._checked_ok(values[i]):
-                raise ValueError('Invalid field value "{}"'.format(values[i]))
-            Const._add_const(field_name, values[i], i)
-
-    @staticmethod
-    def _add_const(group, const, i):
-        if not hasattr(Const, group):
-            setattr(Const, group, _namedtuple(group, ''))
-        obj = getattr(Const, group)
-        setattr(obj, const, i)
-
-    @staticmethod
-    def _checked_ok(value):
-        if not isinstance(value, str):
-            return False
-        if not value.replace('_','').isalnum():
-            return False
-        if value[0].isnumeric():
-            return False
-        return True
+        if hasattr(Const, field_name):
+            raise NameError('Field "{}" already exists.'.format(field_name))
+        const = get_namedtuple(field_name, values)
+        setattr(Const, field_name, const)

--- a/siriuspy/siriuspy/csdevice/const.py
+++ b/siriuspy/siriuspy/csdevice/const.py
@@ -3,6 +3,23 @@
 from collections import namedtuple as _namedtuple
 
 
+def get_namedtuple(name, field_names, values=None):
+    """Return an instance of a namedtuple Class.
+
+    Inputs:
+        - name:  Defines the name of the Class (str).
+        - field_names:  Defines the field names of the Class (iterable).
+        - values (optional): Defines field values . If not given, the value of
+            each field will be its index in 'field_names' (iterable).
+
+    Raises ValueError if at least one of the field names are invalid.
+    Raises TypeError when len(values) != len(field_names)
+    """
+    if values is None:
+        values = range(len(field_names))
+    return _namedtuple(name, field_names)(*values)
+
+
 class Const:
     """Const class defining power supply constants."""
 

--- a/siriuspy/siriuspy/search/ma_search.py
+++ b/siriuspy/siriuspy/search/ma_search.py
@@ -211,7 +211,7 @@ class MASearch:
             MASearch._manames_list = []
             for datum in data:
                 magnet, *psnames = datum
-                MASearch._manames_list.append(magnet)
+                MASearch._manames_list.append(_SiriusPVName(magnet))
                 MASearch._maname_2_psnames_dict[magnet] = tuple(psnames)
                 if 'Fam' not in magnet:
                     famname = _SiriusPVName(magnet)
@@ -226,6 +226,7 @@ class MASearch:
                         else:
                             MASearch._maname_2_trim_dict[maname] += \
                                 tuple(psnames)
+            MASearch._manames_list = sorted(MASearch._manames_list)
             MASearch._psnames_list = _PSSearch.get_psnames()
         else:
             raise Exception(

--- a/siriuspy/siriuspy/search/ma_search.py
+++ b/siriuspy/siriuspy/search/ma_search.py
@@ -138,7 +138,7 @@ class MASearch:
     #     return None
 
     @staticmethod
-    def conv_psname_2_maname_pwrsupply(psname):
+    def conv_psname_2_psmaname(psname):
         """Return power supply maname for a given psname."""
         if MASearch._psnames_list is None:
             MASearch._reload_maname_2_psnames_dict()

--- a/siriuspy/siriuspy/search/ma_search.py
+++ b/siriuspy/siriuspy/search/ma_search.py
@@ -123,19 +123,19 @@ class MASearch:
             return [maname.replace(':PM', ':PU')]
         return [maname.replace(':MA', ':PS')]
 
-    @staticmethod
-    def conv_psname_2_maname(psname):
-        """Return maname for a given psname.
-
-            The maname returned is the name of the magnet or magnet family
-        whose magnet instances has/have coil(s) excited by the given power
-        supply name. For SI and BO dipoles are exceptions.
-        """
-        manames = MASearch.get_manames()
-        for maname in manames:
-            if psname in MASearch._maname_2_psnames_dict[maname]:
-                return maname
-        return None
+    # @staticmethod
+    # def conv_psname_2_maname(psname):
+    #     """Return maname for a given psname.
+    #
+    #         The maname returned is the name of the magnet or magnet family
+    #     whose magnet instances has/have coil(s) excited by the given power
+    #     supply name. For SI and BO dipoles are exceptions.
+    #     """
+    #     manames = MASearch.get_manames()
+    #     for maname in manames:
+    #         if psname in MASearch._maname_2_psnames_dict[maname]:
+    #             return maname
+    #     return None
 
     @staticmethod
     def conv_psname_2_maname_pwrsupply(psname):

--- a/siriuspy/siriuspy/search/ma_search.py
+++ b/siriuspy/siriuspy/search/ma_search.py
@@ -203,31 +203,30 @@ class MASearch:
     @staticmethod
     def _reload_maname_2_psnames_dict():
         """Build a dict of tuples with power supplies of each magnet."""
-        if _web.server_online():
-            text = _web.magnets_excitation_ps_read()
-            data, param_dict = _util.read_text_data(text)
-            MASearch._maname_2_psnames_dict = {}
-            MASearch._maname_2_trim_dict = {}
-            MASearch._manames_list = []
-            for datum in data:
-                magnet, *psnames = datum
-                MASearch._manames_list.append(_SiriusPVName(magnet))
-                MASearch._maname_2_psnames_dict[magnet] = tuple(psnames)
-                if 'Fam' not in magnet:
-                    famname = _SiriusPVName(magnet)
-                    famname = famname.replace(
-                        famname.sub, 'Fam').replace('MA-', 'PS-')
-                    if '-Fam:PS-Q' in famname and famname in psnames:
-                        psnames.remove(famname)
-                        maname = famname.replace('PS-', 'MA-')
-                        if maname not in MASearch._maname_2_trim_dict:
-                            MASearch._maname_2_trim_dict[maname] = \
-                                tuple(psnames)
-                        else:
-                            MASearch._maname_2_trim_dict[maname] += \
-                                tuple(psnames)
-            MASearch._manames_list = sorted(MASearch._manames_list)
-            MASearch._psnames_list = _PSSearch.get_psnames()
-        else:
+        if not _web.server_online():
             raise Exception(
                 'could not read magnet-excitation-ps from web server!')
+        text = _web.magnets_excitation_ps_read()
+        data, param_dict = _util.read_text_data(text)
+        MASearch._maname_2_psnames_dict = {}
+        MASearch._maname_2_trim_dict = {}
+        MASearch._manames_list = []
+        for datum in data:
+            magnet, *psnames = datum
+            MASearch._manames_list.append(_SiriusPVName(magnet))
+            MASearch._maname_2_psnames_dict[magnet] = tuple(psnames)
+            if 'Fam' not in magnet:
+                famname = _SiriusPVName(magnet)
+                famname = famname.replace(
+                    famname.sub, 'Fam').replace('MA-', 'PS-')
+                if '-Fam:PS-Q' in famname and famname in psnames:
+                    psnames.remove(famname)
+                    maname = famname.replace('PS-', 'MA-')
+                    if maname not in MASearch._maname_2_trim_dict:
+                        MASearch._maname_2_trim_dict[maname] = \
+                            tuple(psnames)
+                    else:
+                        MASearch._maname_2_trim_dict[maname] += \
+                            tuple(psnames)
+        MASearch._manames_list = sorted(MASearch._manames_list)
+        MASearch._psnames_list = _PSSearch.get_psnames()

--- a/siriuspy/siriuspy/search/ma_search.py
+++ b/siriuspy/siriuspy/search/ma_search.py
@@ -213,10 +213,11 @@ class MASearch:
         MASearch._manames_list = []
         for datum in data:
             magnet, *psnames = datum
-            MASearch._manames_list.append(_SiriusPVName(magnet))
+            magnet = _SiriusPVName(magnet)
+            MASearch._manames_list.append(magnet)
             MASearch._maname_2_psnames_dict[magnet] = tuple(psnames)
-            if 'Fam' not in magnet:
-                famname = _SiriusPVName(magnet)
+            if 'Fam' != magnet.sub:
+                famname = magnet
                 famname = famname.replace(
                     famname.sub, 'Fam').replace('MA-', 'PS-')
                 if '-Fam:PS-Q' in famname and famname in psnames:

--- a/siriuspy/tests/search/test_ma_search.py
+++ b/siriuspy/tests/search/test_ma_search.py
@@ -35,8 +35,8 @@ class TestMASearch(MockServConf):
         'conv_maname_2_splims',
         'conv_maname_2_psnames',
         'conv_psmaname_2_psnames',
-        'conv_psname_2_maname_pwrsupply',
         # 'conv_psname_2_maname',
+        'conv_psname_2_psmaname',
         'get_maname_2_splims_dict',
         # 'check_maname_ispulsed'
     )
@@ -195,11 +195,11 @@ class TestMASearch(MockServConf):
     #     for psname, maname in TestMASearch.psname2maname.items():
     #         self.assertEqual(MASearch.conv_psname_2_maname(psname), maname)
 
-    def test_conv_psname_2_maname_pwrsupply(self):
-        """Test conv_psname_2_maname_pwrsupply."""
-        self.assertIs(MASearch.conv_psname_2_maname_pwrsupply('INV'), None)
+    def test_conv_psname_2_psmaname(self):
+        """Test conv_psname_2_psmaname."""
+        self.assertIs(MASearch.conv_psname_2_psmaname('INV'), None)
         for psname, maname in TestMASearch.psname2maname_pwrsupply.items():
-            self.assertEqual(MASearch.conv_psname_2_maname_pwrsupply(psname),
+            self.assertEqual(MASearch.conv_psname_2_psmaname(psname),
                              maname)
 
     def test_get_maname_2_splims_dict(self):

--- a/siriuspy/tests/search/test_ma_search.py
+++ b/siriuspy/tests/search/test_ma_search.py
@@ -100,7 +100,7 @@ class TestMASearch(MockServConf):
         'SI-01M1:PS-CH': 'SI-01M1:MA-SDA0',
     }
 
-    psname2maname_pwrsupply = {
+    psname2psmaname = {
         'SI-Fam:PS-B1B2-1': 'SI-Fam:MA-B1B2',
         'SI-Fam:PS-B1B2-2': 'SI-Fam:MA-B1B2',
         'BO-Fam:PS-B-1': 'BO-Fam:MA-B',
@@ -198,7 +198,7 @@ class TestMASearch(MockServConf):
     def test_conv_psname_2_psmaname(self):
         """Test conv_psname_2_psmaname."""
         self.assertIs(MASearch.conv_psname_2_psmaname('INV'), None)
-        for psname, maname in TestMASearch.psname2maname_pwrsupply.items():
+        for psname, maname in TestMASearch.psname2psmaname.items():
             self.assertEqual(MASearch.conv_psname_2_psmaname(psname),
                              maname)
 

--- a/siriuspy/tests/search/test_ma_search.py
+++ b/siriuspy/tests/search/test_ma_search.py
@@ -35,8 +35,8 @@ class TestMASearch(MockServConf):
         'conv_maname_2_splims',
         'conv_maname_2_psnames',
         'conv_psmaname_2_psnames',
-        'conv_psname_2_maname',
         'conv_psname_2_maname_pwrsupply',
+        # 'conv_psname_2_maname',
         'get_maname_2_splims_dict',
         # 'check_maname_ispulsed'
     )
@@ -190,10 +190,10 @@ class TestMASearch(MockServConf):
         for ma, psnames in TestMASearch.maname2psnames.items():
             self.assertEqual(MASearch.conv_maname_2_psnames(ma), psnames)
 
-    def test_psname_2_maname(self):
-        """Test psname_2_maname."""
-        for psname, maname in TestMASearch.psname2maname.items():
-            self.assertEqual(MASearch.conv_psname_2_maname(psname), maname)
+    # def test_psname_2_maname(self):
+    #     """Test psname_2_maname."""
+    #     for psname, maname in TestMASearch.psname2maname.items():
+    #         self.assertEqual(MASearch.conv_psname_2_maname(psname), maname)
 
     def test_conv_psname_2_maname_pwrsupply(self):
         """Test conv_psname_2_maname_pwrsupply."""


### PR DESCRIPTION
The main features of this quick PR are:
 - Make `MASearch._manames_list` an ordered list of `SiriusPVName` objects (just like its `PSSearch` counterpart);
 - Add method `get_namedtuple` to `csdevice/const.py` module;
 - Fix misuse of `collections.namedtuple` in `csdevice.const.Const` class;
 - Comment function MASearch.conv_psname_2_maname and its test;
 - Rename MASearch.conv_psname_2_maname_pwrsupply to conv_psname_2_psmaname;

Please, let me know if this breaks some of your code.