### PR TITLE
Added access to config_type endpoint

### DIFF
--- a/siriuspy/siriuspy/servconf/conf_service.py
+++ b/siriuspy/siriuspy/servconf/conf_service.py
@@ -53,6 +53,11 @@ class ConfigService:
         _logging.getLogger(__name__).\
             info("HTTP request will be made to {}".format(self._url))
 
+    @property
+    def url(self):
+        """Server URL."""
+        return self._url
+
     @staticmethod
     def get_config_types():
         """Get all configuration types."""
@@ -62,6 +67,18 @@ class ConfigService:
         """Get lists by name and config."""
         url_params = "/{}/{}".format(config_type, name)
         url = self._url + self.CONFIGS_ENDPOINT + url_params
+        request = _Request(url=url, method="GET")
+        return self._make_request(request)
+
+    def get_types(self):
+        """Get lists by name and config."""
+        url = self._url + '/config_types'
+        request = _Request(url=url, method="GET")
+        return self._make_request(request)
+
+    def get_names_by_type(self, config_type):
+        """Get lists by name and config."""
+        url = self._url + '/config_types/' + config_type
         request = _Request(url=url, method="GET")
         return self._make_request(request)
 

--- a/siriuspy/tests/servconf/test_config_service.py
+++ b/siriuspy/tests/servconf/test_config_service.py
@@ -20,8 +20,11 @@ class TestConfigService(unittest.TestCase):
 
     api = {
         "CONFIGS_ENDPOINT",
+        "url",
         "get_config_types",
         "get_config",
+        "get_types",
+        "get_names_by_type",
         "update_config",
         "insert_config",
         "find_configs",


### PR DESCRIPTION
Added two method to `ConfigService`, in order to give access to the new `config_type` endpoint in the configuration database REST API.