### PR TITLE
Add bsmp_init_group when invalid_id response is received

### DIFF
--- a/siriuspy/siriuspy/pwrsupply/prucontroller.py
+++ b/siriuspy/siriuspy/pwrsupply/prucontroller.py
@@ -1042,6 +1042,9 @@ class PRUController:
                     copy_var_vals[id][self._params.ConstBSMP.V_I_LOAD2] += \
                         0.00001*_random.uniform(-1.0, +1.0)
 
+            elif ack[id] == _Response.invalid_id:
+                self._connected[id] = False
+                self._bsmp_init_groups()
             else:
                 self._connected[id] = False
         # processing time up to this point: 19.4 ms @ BBB1

--- a/siriuspy/siriuspy/pwrsupply/prucontroller.py
+++ b/siriuspy/siriuspy/pwrsupply/prucontroller.py
@@ -1015,6 +1015,7 @@ class PRUController:
         # --- update variables, if ack is ok
         nr_devs = len(self.device_ids)
         var_ids = self._params.groups[group_id]
+        create_groups = False
         for id in device_ids:
             if ack[id] == _Response.ok:
                 self._connected[id] = True
@@ -1044,11 +1045,13 @@ class PRUController:
 
             elif ack[id] == _Response.invalid_id:
                 self._connected[id] = False
-                self._bsmp_init_groups()
+                create_groups = True
             else:
                 self._connected[id] = False
         # processing time up to this point: 19.4 ms @ BBB1
         # print('time3: ', _time.time() - t0)
+        if create_groups:
+            self._bsmp_init_groups()
 
         # update psc_state
         for id in self.device_ids:


### PR DESCRIPTION
This PR fixes the problem that occurs when the IOC is running, and someone sends the BSMP command `reset_udc`. 

In this command the BSMP entities will be reset, causing all groups to be removed. This leaves the IOC in a states where it continues to read the groups but they don't exist causing the PVs to be disconnected and not being updted.

This PR adds an ack check and create the groups again in case in receives an `invalid_id` response.