### PR TITLE
Fix PSCycle

### DIFF
--- a/siriuspy/siriuspy/cycle/main.py
+++ b/siriuspy/siriuspy/cycle/main.py
@@ -317,21 +317,10 @@ class CycleController:
         self._checks_final_result[psname] = \
             self.cyclers[psname].check_final_state(self.mode)
 
-    def reset_all_subsystems(self):
+    def restore_timing_initial_state(self):
         """Reset all subsystems."""
         if self._only_linac:
             return
-        self._update_log('Setting power supplies to SlowRef...')
-        threads = list()
-        for ps in self.psnames:
-            if 'LI' in ps:
-                continue
-            t = _thread.Thread(
-                target=self.cyclers[ps].set_opmode_slowref, daemon=True)
-            threads.append(t)
-            t.start()
-        for t in threads:
-            t.join()
         self._update_log('Restoring Timing initial state...')
         self._timing.restore_initial_state()
         self._update_log(done=True)
@@ -387,7 +376,7 @@ class CycleController:
             return
         self.check_all_pwrsupplies_final_state()
         _time.sleep(4)  # TODO: replace by checks
-        self.reset_all_subsystems()
+        self.restore_timing_initial_state()
 
         # Indicate cycle end
         self._update_log('Cycle finished!')

--- a/siriuspy/siriuspy/epics/psdiag_pv.py
+++ b/siriuspy/siriuspy/epics/psdiag_pv.py
@@ -57,7 +57,6 @@ class PSStatusPV(Computer):
     MAOPMD_SEL = 6
     PSCONN_MON = 7
     WAVFRM_MON = 8
-    WFMREF_MON = 9
 
     DTOLWFM_DICT = dict()
 
@@ -115,12 +114,11 @@ class PSStatusPV(Computer):
             # waveform diff?
             elif (psname.sec == 'BO') and (sts == _PSConst.States.RmpWfm):
                 mon = computed_pv.pvs[PSStatusPV.WAVFRM_MON].value
-                ref = computed_pv.pvs[PSStatusPV.WFMREF_MON].value
                 if psname not in PSStatusPV.DTOLWFM_DICT.keys():
                     pstype = _PSSearch.conv_psname_2_pstype(psname)
                     PSStatusPV.DTOLWFM_DICT[psname] = _PSSearch.get_splims(
                         pstype, 'DTOL_WFM')
-                if not _np.allclose(mon, ref,
+                if not _np.allclose(mon, 0.0,
                                     atol=PSStatusPV.DTOLWFM_DICT[psname]):
                     value |= PSStatusPV.BIT_BOWFMDIFF
         else:


### PR DESCRIPTION
After cycling finished, set power supplies OpMode-Sel to SlowRef and wait for OpMode-Sts before restore timing initial state. This change bypass bug in timing of sending a new trigger to power supplies when restoring initial state.