### PR TITLE
Change default value of PS parameters

### DIFF
--- a/siriuspy/siriuspy/pwrsupply/functions.py
+++ b/siriuspy/siriuspy/pwrsupply/functions.py
@@ -6,7 +6,6 @@ an `execute` method.
 
 from siriuspy.pwrsupply.bsmp import ConstPSBSMP as _consts_psbsmp
 from siriuspy.csdevice.pwrsupply import Const as _consts_ps
-from siriuspy.pwrsupply.status import PSCStatus as _PSCStatus
 
 
 class Function:

--- a/siriuspy/siriuspy/pwrsupply/prucontroller.py
+++ b/siriuspy/siriuspy/pwrsupply/prucontroller.py
@@ -526,7 +526,7 @@ class PRUController:
 
     def _bsmp_update(self):
 
-        time0 = _time()
+        # time0 = _time()
 
         # update timestamp
         self._timestamp_update = _time()
@@ -541,9 +541,9 @@ class PRUController:
             dev_id = self._device_ids[self._wfm_update_dev_idx]
             self._bsmp_update_wfm(dev_id)
 
-        time1 = _time()
-        print('{} devices, update total time {}'.format(
-            len(self._device_ids), 1000*(time1 - time0)))
+        # time1 = _time()
+        # print('{} devices, update total time {}'.format(
+        #     len(self._device_ids), 1000*(time1 - time0)))
 
     def _bsmp_update_variables(self):
 

--- a/siriuspy/siriuspy/pwrsupply/prucontroller.py
+++ b/siriuspy/siriuspy/pwrsupply/prucontroller.py
@@ -389,6 +389,8 @@ class PRUController:
     def _loop_scan(self):
         while self._running:
 
+            time0 = _time()
+
             # run scan method once
             if self.scanning and self._scan_interval != 0:
                 self.bsmp_scan()
@@ -397,7 +399,9 @@ class PRUController:
             self._scan_interval = self._get_scan_interval()
 
             # wait for time_interval
-            _sleep(self._scan_interval)
+            dtime = _time() - time0
+            if dtime < self._scan_interval:
+                _sleep(self._scan_interval - dtime)
 
     def _loop_process(self):
         while self._running:
@@ -522,7 +526,7 @@ class PRUController:
 
     def _bsmp_update(self):
 
-        # time0 = _time()
+        time0 = _time()
 
         # update timestamp
         self._timestamp_update = _time()
@@ -530,19 +534,16 @@ class PRUController:
         # update variables
         self._bsmp_update_variables()
 
-        # return of wfm is not to be updated
-        if not self._wfm_update:
-            return  # does not update wfm!
-
         # update device wfm curves cyclically
-        self._wfm_update_dev_idx = \
-            (self._wfm_update_dev_idx + 1) % len(self._device_ids)
-        dev_id = self._device_ids[self._wfm_update_dev_idx]
-        self._bsmp_update_wfm(dev_id)
+        if self._wfm_update:
+            self._wfm_update_dev_idx = \
+                (self._wfm_update_dev_idx + 1) % len(self._device_ids)
+            dev_id = self._device_ids[self._wfm_update_dev_idx]
+            self._bsmp_update_wfm(dev_id)
 
-        # time1 = _time()
-        # print('devices: {}, time {}'.format(
-        #     self._device_ids, 1000*(time1 - time0)))
+        time1 = _time()
+        print('{} devices, update total time {}'.format(
+            len(self._device_ids), 1000*(time1 - time0)))
 
     def _bsmp_update_variables(self):
 

--- a/siriuspy/siriuspy/pwrsupply/psmodel.py
+++ b/siriuspy/siriuspy/pwrsupply/psmodel.py
@@ -89,8 +89,6 @@ class _PSModel:
         # # ----- class Analog Variables -----
         # P_ANALOG_MAX = 46
         # P_ANALOG_MIN = 47
-
-
         # # ----- class Control -----
         # P_CTRL_FREQ_CONTROL_ISR = 11
         # P_CTRL_FREQ_TIME_SLICER = 12

--- a/siriuspy/siriuspy/pwrsupply/psupply.py
+++ b/siriuspy/siriuspy/pwrsupply/psupply.py
@@ -3,6 +3,7 @@
 # import random as _random
 import time as _time
 import numpy as _np
+import math as _math
 from siriuspy.bsmp import SerialError as _SerialError
 
 
@@ -34,9 +35,9 @@ class PSupply:
         """Init."""
         self._psbsmp = psbsmp
         self._connected = None
-        self._groups = self._init_groups()
-        self._variables = self._init_variables()
-        self._curves = self._init_curves()
+        self._groups = PSupply._init_groups()
+        self._variables = PSupply._init_variables()
+        self._curves = PSupply._init_curves()
         self._parameters = self._init_parameters()
         self._wfm_rb = None
         self._wfmref_mon = None
@@ -233,22 +234,28 @@ class PSupply:
         tstamp = self._timestamp_update_parameters
         if tstamp is None or (now - tstamp) >= interval:
             parameters = self._psbsmp.entities.parameters
+            conn_status_ok = True
             for eid in parameters.eids:
                 parameter = parameters[eid]
                 counter = parameter['count']
                 if eid != self._psbsmp.CONST.P_PS_NAME and counter > 1:
-                    value = _np.zeros(counter) * float('NaN')
+                    value = _np.zeros(counter)
                     for idx in range(counter):
                         value[idx] = self._psbsmp.parameter_read(eid, idx)
+                        if value[idx] is None:
+                            conn_status_ok = False
+                        if _math.isnan(value[idx]):
+                            value[idx] = 0
                 else:
                     value = self._psbsmp.parameter_read(eid)
+                    if value is None:
+                        conn_status_ok = False
                 self._parameters[eid] = value
                 # print(eid, value)
-            if value is not None:
-                self._timestamp_update_variables = now
+            if conn_status_ok:
+                self._timestamp_update_parameters = now
                 return True
-            else:
-                return False
+            return False
         return True
 
     def reset_variables_groups(self, groups):
@@ -260,13 +267,19 @@ class PSupply:
             ValueError('Could not reset groups of variables!')
         return True
 
-    def _init_groups(self):
+    @staticmethod
+    def _init_groups():
+        # NOTE: template to be expanded, if necessary.
         return dict()
 
-    def _init_variables(self):
+    @staticmethod
+    def _init_variables():
+        # NOTE: template to be expanded, if necessary.
         return dict()
 
-    def _init_curves(self):
+    @staticmethod
+    def _init_curves():
+        # NOTE: template to be expanded, if necessary.
         return dict()
 
     def _init_parameters(self):

--- a/siriuspy/siriuspy/pwrsupply/tests/utils.py
+++ b/siriuspy/siriuspy/pwrsupply/tests/utils.py
@@ -130,7 +130,7 @@ def print_status(ps_list):
         address = ps.channel.address
         _, ps_status = process_response(
             ps.read_variable(
-                ps.CONST_PSBSMP.V_PS_STATUS, timeout=100),
+                ps.CONST.V_PS_STATUS, timeout=100),
             'ps_status {}'.format(address))
 
         status = PSCStatus(ps_status=ps_status)


### PR DESCRIPTION
PS firmware returns *NaN* for some unused parameters, depending on the psmodel. *NaN* always triggers Pv value/timestamp updates, thus generating storage data fro epics archiver. In this PR IOCs will replace *NaN* by numerical zero as default uninitialized value.