### PR TITLE
ExcData interpolation methods optimization

### DIFF
--- a/siriuspy/siriuspy/magnet/excdata.py
+++ b/siriuspy/siriuspy/magnet/excdata.py
@@ -85,13 +85,15 @@ class ExcitationData:
         multipoles = self.multipoles[multipole_type][harmonic]
         return min(multipoles) <= value <= max(multipoles)
 
-    def interp_curr2mult(self, currents):
+    def interp_curr2mult(self, currents, only_main_harmonic=False):
         """Interpolate multipoles for current values."""
         curr = self.currents
         multipoles = {'normal': {}, 'skew': {}}
+        harmonics = (self.main_multipole_harmonic, ) if \
+            only_main_harmonic else self.harmonics
         if _np.isscalar(currents):
             currents = _np.array([currents])
-            for harm in self.harmonics:
+            for harm in harmonics:
                 # normal component
                 mpole = self.multipoles['normal'][harm]
                 interp = ExcitationData._calc_interp(currents, curr, mpole)
@@ -102,7 +104,7 @@ class ExcitationData:
                 multipoles['skew'][harm] = interp[0]
         else:
             currents = _np.array(currents)
-            for harm in self.harmonics:
+            for harm in harmonics:
                 # normal component
                 mpole = self.multipoles['normal'][harm]
                 interp = ExcitationData._calc_interp(currents, curr, mpole)

--- a/siriuspy/siriuspy/magnet/normalizer.py
+++ b/siriuspy/siriuspy/magnet/normalizer.py
@@ -53,7 +53,7 @@ class _MagnetNormalizer:
         if currents is None:
             return None
         intfields = self._conv_current_2_intfield(currents)
-        # TODO: really necessary? ---
+        # NOTE: really necessary? ---
         if intfields is None:
             if isinstance(currents, (int, float)):
                 return 0.0
@@ -78,15 +78,16 @@ class _MagnetNormalizer:
     # --- normalizer aux. methods ---
 
     def _conv_current_2_intfield(self, currents):
-        mpoles = self._conv_current_2_multipoles(currents)
+        mpoles = self._conv_current_2_multipoles(
+            currents, only_main_harmonic=True)
         if mpoles is None:
             return None
-        mf = self._mfmult
-        intfield = mpoles[mf['type']][mf['harmonic']]
+        mfm = self._mfmult
+        intfield = mpoles[mfm['type']][mfm['harmonic']]
         return intfield
 
-    def _conv_current_2_multipoles(self, currents):
-        # TODO: think about implementation of this function: magnets with
+    def _conv_current_2_multipoles(self, currents, only_main_harmonic=False):
+        # NOTE: think about implementation of this function for magnets with
         # multiple functions...
         if currents is None:
             return None
@@ -94,11 +95,11 @@ class _MagnetNormalizer:
         if self._magfunc != 'dipole':
             # for psname in self._madata.psnames:
             excdata = self._madata.excdata(self._psname)
-            mpoles = excdata.interp_curr2mult(currents)
+            mpoles = excdata.interp_curr2mult(currents, only_main_harmonic)
             msum = _mutil.sum_magnetic_multipoles(msum, mpoles)
         else:
             excdata = self._madata.excdata(self._psname)
-            mpoles = excdata.interp_curr2mult(currents)
+            mpoles = excdata.interp_curr2mult(currents, only_main_harmonic)
             msum = _mutil.sum_magnetic_multipoles(msum, mpoles)
         return msum
 

--- a/siriuspy/siriuspy/meas/lienergy/main.py
+++ b/siriuspy/siriuspy/meas/lienergy/main.py
@@ -153,7 +153,8 @@ class CalcEnergy(_BaseClass, _Const):
         """."""
         if self._currents.size == 0:
             return
-        mult = self._excdata.interp_curr2mult(currents=self._currents)
+        mult = self._excdata.interp_curr2mult(
+            currents=self._currents, only_main_harmonic=True)
         self._intdipole = mult['normal'][0]
 
     def _perform_analysis(self):


### PR DESCRIPTION
trivial improvement of excdata methods, useful for the case when only the main harmonic multipole fitting is necessary, such as for control system current-strength conversions.

```python
n = NormalizerFactory.create('BO-01U:MA-CH')
v = [-10 + i/10 * (10 + 10) for i in range(11)]
n.conv_current_2_strength(v, strengths_dipole=3)
```
from ~ 413 us to ~ 54 us.