### PR TITLE
Magnet Factory Relocation

### DIFF
--- a/siriuspy/siriuspy/devices/psconv.py
+++ b/siriuspy/siriuspy/devices/psconv.py
@@ -1,7 +1,7 @@
 """Define Power Supply Property and Strength Devices."""
 
 from ..namesys import SiriusPVName as _SiriusPVName
-from ..factory import NormalizerFactory as _NormalizerFactory
+from ..magnet.factory import NormalizerFactory as _NormalizerFactory
 
 from .device import Devices as _Devices
 from .syncd import DevicesSync as _DevicesSync

--- a/siriuspy/siriuspy/magnet/factory.py
+++ b/siriuspy/siriuspy/magnet/factory.py
@@ -3,10 +3,12 @@
 NormalizerFactory
     used to create magnet normalizers
 """
-from .search import PSSearch as _PSSearch
-from .search import MASearch as _MASearch
-from .magnet import util as _mutil
-from .magnet import normalizer as _norm
+
+from ..search import PSSearch as _PSSearch
+from ..search import MASearch as _MASearch
+
+from . import util as _mutil
+from . import normalizer as _norm
 
 
 class NormalizerFactory:

--- a/siriuspy/siriuspy/meas/liemit/main.py
+++ b/siriuspy/siriuspy/meas/liemit/main.py
@@ -7,7 +7,7 @@ from epics import PV as _PV
 
 import mathphys.constants as _consts
 
-from ...factory import NormalizerFactory as _NormFact
+from ...magnet.factory import NormalizerFactory as _NormFact
 
 from ..util import BaseClass as _BaseClass, ProcessImage as _ProcessImage
 
@@ -16,6 +16,8 @@ E0 = _consts.electron_rest_energy / _consts.elementary_charge * 1e-6  # in MeV
 
 
 class CalcEmmitance(_BaseClass):
+    """."""
+
     X = 0
     Y = 1
     PLACES = ('li', 'tb-qd2a', 'tb-qf2a')

--- a/siriuspy/siriuspy/ramp/magnet.py
+++ b/siriuspy/siriuspy/ramp/magnet.py
@@ -2,9 +2,10 @@
 
 from .. import util as _util
 from ..namesys import SiriusPVName as _SiriusPVName
-from ..magnet import util as _mutil
-from ..factory import NormalizerFactory as _NormalizerFactory
 from ..search import PSSearch as _PSSearch, MASearch as _MASearch
+from ..magnet import util as _mutil
+from ..magnet.factory import NormalizerFactory as _NormalizerFactory
+
 
 from .exceptions import RampInvalidDipoleWfmParms as \
     _RampInvalidDipoleWfmParms

--- a/siriuspy/tests/magnet/test_factory.py
+++ b/siriuspy/tests/magnet/test_factory.py
@@ -4,13 +4,13 @@
 
 from unittest import mock, TestCase
 import siriuspy.util as util
-import siriuspy.factory as factory
-from siriuspy.factory import NormalizerFactory
+import siriuspy.magnet.factory as factory
+from siriuspy.magnet.factory import NormalizerFactory
 from siriuspy.magnet.normalizer \
     import DipoleNormalizer, MagnetNormalizer, TrimNormalizer
 
 
-valid_interface = (
+PUB_INTERFACE = (
     'NormalizerFactory',
 )
 
@@ -21,10 +21,10 @@ class TestMagnetFactory(TestCase):
 
     def test_public_interface(self):
         """Test module's public interface."""
-        valid = util.check_public_interface_namespace(factory, valid_interface)
+        valid = util.check_public_interface_namespace(factory, PUB_INTERFACE)
         self.assertTrue(valid)
 
-    @mock.patch('siriuspy.factory._norm.DipoleNormalizer', autospec=True)
+    @mock.patch('siriuspy.magnet.factory._norm.DipoleNormalizer', autospec=True)
     def test_dipole_creation(self, mock_data):
         """Test Factory.create. dipole creation."""
         maname = 'SI-Fam:MA-B1B2'
@@ -32,7 +32,7 @@ class TestMagnetFactory(TestCase):
         magnet = NormalizerFactory.create(maname=maname)
         self.assertIsInstance(magnet, DipoleNormalizer)
 
-    @mock.patch('siriuspy.factory._norm.MagnetNormalizer', autospec=True)
+    @mock.patch('siriuspy.magnet.factory._norm.MagnetNormalizer', autospec=True)
     def test_magnet_creation(self, mock_data):
         """Test Factory.create magnet creation."""
         maname = 'SI-Fam:MA-QDA'
@@ -40,7 +40,7 @@ class TestMagnetFactory(TestCase):
         magnet = NormalizerFactory.create(maname=maname)
         self.assertIsInstance(magnet, MagnetNormalizer)
 
-    @mock.patch('siriuspy.factory._norm.MagnetNormalizer', autospec=True)
+    @mock.patch('siriuspy.magnet.factory._norm.MagnetNormalizer', autospec=True)
     def test_pulsed_magnet_creation(self, mock_data):
         """Test Factory.create magnet creation."""
         maname = 'SI-01SA:PM-InjDpKckr'
@@ -48,7 +48,7 @@ class TestMagnetFactory(TestCase):
         magnet = NormalizerFactory.create(maname=maname)
         self.assertIsInstance(magnet, MagnetNormalizer)
 
-    @mock.patch('siriuspy.factory._norm.TrimNormalizer', autospec=True)
+    @mock.patch('siriuspy.magnet.factory._norm.TrimNormalizer', autospec=True)
     def test_trim_creation(self, mock_data):
         """Test Factory.create trim creation."""
         maname = 'SI-01M1:MA-QDA'

--- a/siriuspy/tests/magnet/tests_normalizer.py
+++ b/siriuspy/tests/magnet/tests_normalizer.py
@@ -27,9 +27,8 @@ class DipoleNormalizerTest(TestCase):
                "strength": 2.9377924330512246},
         "SI": {"name": "SI-Fam:MA-B1B2",
                "current": 394.1,
-            #    "strength": 3.0000383740663543}
-               "strength": 2.9340661454870647}
-    }
+               "strength": 2.9340661454870647},
+        }
 
     def setUp(self):
         """Create strength object."""


### PR DESCRIPTION
move module siriuspy.factory to subpackage magnet, to where it naturally belongs. I think it was originally located at the top of siriuspy with the ideia that all other factories would eventually be concentrated in this module along the way. practice proved otherwise.