### PR TITLE
Move namedtuple

### DIFF
--- a/siriuspy/siriuspy/csdev.py
+++ b/siriuspy/siriuspy/csdev.py
@@ -1,6 +1,9 @@
 """Control system Device Util Module."""
 
 import copy as _copy
+
+from mathphys.functions import get_namedtuple as _get_namedtuple
+
 from . import util as _util
 from .clientweb import beaglebone_ip_list as _bbb_ip_list
 from .search import PSSearch as _PSSearch
@@ -28,15 +31,15 @@ _et = ETypes  # syntactic sugar
 class Const:
     """Const class defining power supply constants."""
 
-    DsblEnbl = _util.get_namedtuple('DsblEnbl', _et.DSBL_ENBL)
-    OffOn = _util.get_namedtuple('OffOn', _et.OFF_ON)
-    CloseOpen = _util.get_namedtuple('CloseOpen', _et.CLOSE_OPEN)
-    DisconnConn = _util.get_namedtuple('DisconnConn', _et.DISCONN_CONN)
+    DsblEnbl = _get_namedtuple('DsblEnbl', _et.DSBL_ENBL)
+    OffOn = _get_namedtuple('OffOn', _et.OFF_ON)
+    CloseOpen = _get_namedtuple('CloseOpen', _et.CLOSE_OPEN)
+    DisconnConn = _get_namedtuple('DisconnConn', _et.DISCONN_CONN)
 
     @staticmethod
     def register(name, field_names, values=None):
         """Register namedtuple."""
-        return _util.get_namedtuple(name, field_names, values)
+        return _get_namedtuple(name, field_names, values)
 
 
 def add_pvslist_cte(database, prefix=''):

--- a/siriuspy/siriuspy/csdev.py
+++ b/siriuspy/siriuspy/csdev.py
@@ -9,7 +9,7 @@ from .clientweb import beaglebone_ip_list as _bbb_ip_list
 from .search import PSSearch as _PSSearch
 
 
-_DEV_2_IOC_IP_DICT = None
+_DEV_2_IOC_IP_DICT = dict()
 
 
 class ETypes:
@@ -58,30 +58,28 @@ def add_pvslist_cte(database, prefix=''):
 
 def get_device_2_ioc_ip(reload=False):
     """Return a dict of ioc IP numbers for csdevices."""
-    if _DEV_2_IOC_IP_DICT is None or reload is True:
+    if not _DEV_2_IOC_IP_DICT or reload:
         _reload_device_2_ioc_ip()
     return _copy.deepcopy(_DEV_2_IOC_IP_DICT)
 
 
 def _reload_device_2_ioc_ip():
-    global _DEV_2_IOC_IP_DICT
-    _DEV_2_IOC_IP_DICT = dict()
 
     # beaglebone IPs
     text, _ = _util.read_text_data(_bbb_ip_list())
     for item in text:
         if len(item) == 2:
-            bbbname, ip = item
-            _DEV_2_IOC_IP_DICT[bbbname] = ip
+            bbbname, ipm = item
+            _DEV_2_IOC_IP_DICT[bbbname] = ipm
 
     # power supplies
     dic = dict()
-    for bbbname, ip in _DEV_2_IOC_IP_DICT.items():
+    for bbbname, ipm in _DEV_2_IOC_IP_DICT.items():
         try:
             bsmps = _PSSearch.conv_bbbname_2_bsmps(bbbname)
             for bsmp in bsmps:
                 psname, _ = bsmp
-                dic[psname] = ip
+                dic[psname] = ipm
         except KeyError:
             pass
     _DEV_2_IOC_IP_DICT.update(dic)

--- a/siriuspy/siriuspy/sofb/csdev.py
+++ b/siriuspy/siriuspy/sofb/csdev.py
@@ -129,9 +129,12 @@ class SOFBTLines(ConstTLines):
         self.cv_nicknames = _PSSearch.get_psnicknames(self.cv_names)
         self.bpm_pos = _BPMSearch.get_positions(self.bpm_names)
 
-        func = lambda x: x.substitute(dis='MA' if x.dis == 'PS' else 'PM')
-        self.ch_pos = _MASearch.get_mapositions(map(func, self.ch_names))
-        self.cv_pos = _MASearch.get_mapositions(map(func, self.cv_names))
+        self.ch_pos = _MASearch.get_mapositions(map(
+            lambda x: x.substitute(dis='MA' if x.dis == 'PS' else 'PM'),
+            self.ch_names))
+        self.cv_pos = _MASearch.get_mapositions(map(
+            lambda x: x.substitute(dis='MA' if x.dis == 'PS' else 'PM'),
+            self.cv_names))
         self.nr_ch = len(self.ch_names)
         self.nr_cv = len(self.cv_names)
         self.nr_chcv = self.nr_ch + self.nr_cv
@@ -302,7 +305,6 @@ class SOFBTLines(ConstTLines):
     def get_orbit_database(self, prefix=''):
         """Return Orbit database."""
         nbpm = self.nr_bpms
-        evt = self.evt_acq_name
         pvs = [
             'RefOrbX-SP', 'RefOrbX-RB',
             'RefOrbY-SP', 'RefOrbY-RB',

--- a/siriuspy/siriuspy/sofb/csdev.py
+++ b/siriuspy/siriuspy/sofb/csdev.py
@@ -4,7 +4,6 @@ from copy import deepcopy as _dcopy
 
 from .. import csdev as _csdev
 from ..namesys import SiriusPVName as _PVName
-from ..util import get_namedtuple as _get_namedtuple
 from ..search import MASearch as _MASearch, BPMSearch as _BPMSearch, \
     LLTimeSearch as _TISearch, HLTimeSearch as _HLTISearch, \
     PSSearch as _PSSearch
@@ -667,7 +666,7 @@ class SOFBSI(SOFBRings, ConstSI):
         evts = _HLTISearch.get_hl_trigger_allowed_evts(self.trigger_cor_name)
         vals = _cstiming.get_hl_trigger_database(self.trigger_cor_name)
         vals = tuple([vals['Src-Sel']['enums'].index(evt) for evt in evts])
-        self.CorrExtEvtSrc = _get_namedtuple('CorrExtEvtSrc', evts, vals)
+        self.CorrExtEvtSrc = self.register('CorrExtEvtSrc', evts, vals)
         self.circum = 518.396  # in meter
         self.rev_per = self.circum / 299792458  # in seconds
 

--- a/siriuspy/siriuspy/util.py
+++ b/siriuspy/siriuspy/util.py
@@ -255,24 +255,6 @@ def check_public_interface_namespace(namespace, valid_interface,
     return True
 
 
-def get_namedtuple(name, field_names, values=None):
-    """Return an instance of a namedtuple Class.
-
-    Inputs:
-        - name:  Defines the name of the Class (str).
-        - field_names:  Defines the field names of the Class (iterable).
-        - values (optional): Defines field values . If not given, the value of
-            each field will be its index in 'field_names' (iterable).
-
-    Raises ValueError if at least one of the field names are invalid.
-    Raises TypeError when len(values) != len(field_names)
-    """
-    if values is None:
-        values = range(len(field_names))
-    field_names = [f.replace(' ', '_') for f in field_names]
-    return _namedtuple(name, field_names)(*values)
-
-
 # This solution was copied from:
 # https://stackoverflow.com/questions/5189699/how-to-make-a-class-property
 class ClassProperty:

--- a/siriuspy/tests/test_util.py
+++ b/siriuspy/tests/test_util.py
@@ -25,7 +25,6 @@ PUB_INTERFACE = (
     'get_bit',
     'mode',
     'check_public_interface_namespace',
-    'get_namedtuple',
     'ClassProperty',
     )
 
@@ -281,18 +280,3 @@ class TestUtil(TestCase):
         valid = util.check_public_interface_namespace(
             NameSpace, public_interface, print_flag=False)
         self.assertFalse(valid)
-
-    def test_get_namedtuple(self):
-        """Test get_namedtuple."""
-        fields = ('a', 'b', 'c')
-        values = (1, 4, 5)
-        ntp = util.get_namedtuple('A', fields, values)
-        self.assertTrue(ntp.__class__.__name__ == 'A')
-        self.assertTrue(ntp._fields == fields)
-        self.assertTrue(ntp.a == 1 and ntp.b == 4 and ntp.c == 5)
-        fields = ('a', 'b', 'c')
-        ntp = util.get_namedtuple('A', fields)
-        self.assertTrue(ntp.a == 0 and ntp.b == 1 and ntp.c == 2)
-        fields = ('a a', 'b b', 'c')
-        ntp = util.get_namedtuple('A', fields)
-        self.assertTrue(ntp._fields == ('a_a', 'b_b', 'c'))


### PR DESCRIPTION
This PR moves the method `get_namedtuple` from this repo to `mathphys`.
I decided to do this because I needed this function in another repo (`apsuite`) and instead of importing `siriuspy`, I prefer to import `mathphys`, since it is more basic package.
Also, the scope of this method is very general, hence, more suitable for `mathphys` than `siriuspy`.
I noticed there are other methods in `siriuspy` which could be moved to `mathphys`. Maybe we could do that in the future.

OBS.: Tests are failing because the mathphys code (lnls-fac/mathphys#10) was not merged yet.