### PR TITLE
Move EthBrigdeClient import to machine_application repo

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-numpy==1.18
-pyepics==3.4.0
-python-dateutil==2.8.1
-requests==2.22.0
-six==1.13.0
+numpy>=1.18
+pyepics>=3.4.0
+python-dateutil>=2.8.1
+requests>=2.22.0
+six>=1.13.0

--- a/siriuspy/siriuspy/pwrsupply/factory.py
+++ b/siriuspy/siriuspy/pwrsupply/factory.py
@@ -28,13 +28,13 @@ class BBBFactory:
     _regexp_constant_bsmp_init = _re.compile('^(Param|Version).*-Cte$')
 
     @staticmethod
-    def create(ethbridgeclient, bbbname=None):
+    def create(ethbridgeclnt_class, bbbname=None):
         """Return BBB object."""
         # create timestamp used in all TimestampBoot-Cte PVs
         timestamp = _time.time()
 
         # create PRU used for low-level communication
-        pru = _PRU(ethbridgeclient, bbbname=bbbname)
+        pru = _PRU(ethbridgeclnt_class, bbbname=bbbname)
 
         # create DequeThread that queue all serial operations
         prucqueue = _DequeThread()

--- a/siriuspy/siriuspy/pwrsupply/factory.py
+++ b/siriuspy/siriuspy/pwrsupply/factory.py
@@ -28,13 +28,13 @@ class BBBFactory:
     _regexp_constant_bsmp_init = _re.compile('^(Param|Version).*-Cte$')
 
     @staticmethod
-    def create(bbbname=None):
+    def create(ethbridgeclient, bbbname=None):
         """Return BBB object."""
         # create timestamp used in all TimestampBoot-Cte PVs
         timestamp = _time.time()
 
         # create PRU used for low-level communication
-        pru = _PRU(bbbname=bbbname)
+        pru = _PRU(ethbridgeclient, bbbname=bbbname)
 
         # create DequeThread that queue all serial operations
         prucqueue = _DequeThread()

--- a/siriuspy/siriuspy/pwrsupply/pructrl/pru.py
+++ b/siriuspy/siriuspy/pwrsupply/pructrl/pru.py
@@ -60,7 +60,7 @@ class PRUInterface:
 class PRU(PRUInterface):
     """Functions for the programmable real-time unit."""
 
-    def __init__(self, ethbridgeclient, bbbname=None, ip_address=None):
+    def __init__(self, ethbridgeclnt_class, bbbname=None, ip_address=None):
         """Init method."""
         # if ip address was not given, get it from bbbname
         if ip_address is None:
@@ -70,7 +70,7 @@ class PRU(PRUInterface):
         print('IP_ADDRESS: ', ip_address)
 
         # start communication threads
-        self._ethbrigde = ethbridgeclient(
+        self._ethbrigde = ethbridgeclnt_class(
             ip_address=ip_address, use_general=False)
         self._ethbrigde.threads_start()
 

--- a/siriuspy/siriuspy/pwrsupply/pructrl/pru.py
+++ b/siriuspy/siriuspy/pwrsupply/pructrl/pru.py
@@ -1,19 +1,8 @@
 """Module implementing PRU elements."""
 import time as _time
 
-import PRUserial485 as _PRUserial485
-from PRUserial485 import EthBrigdeClient as _EthBrigdeClient
 
 from ... import csdev as _csdev
-
-
-# check PRUserial485 package version
-__version_eth_required__ = '2.5.0'  # eth-PRUserial485
-__version_eth_implmntd__ = _PRUserial485.__version__
-if __version_eth_implmntd__ != __version_eth_required__:
-    _ERR_MSG = 'Incompatible PRUserial485 library versions: {} != {}'.format(
-        __version_eth_implmntd__, __version_eth_required__)
-    raise ValueError(_ERR_MSG)
 
 
 class PRUInterface:
@@ -71,12 +60,8 @@ class PRUInterface:
 class PRU(PRUInterface):
     """Functions for the programmable real-time unit."""
 
-    def __init__(self, bbbname=None, ip_address=None):
+    def __init__(self, ethbridgeclient, bbbname=None, ip_address=None):
         """Init method."""
-        # check if appropriate conditions are met
-        if _PRUserial485 is None:
-            raise ValueError('module PRUserial485 is not installed!')
-
         # if ip address was not given, get it from bbbname
         if ip_address is None:
             dev2ips = _csdev.get_device_2_ioc_ip()
@@ -85,7 +70,7 @@ class PRU(PRUInterface):
         print('IP_ADDRESS: ', ip_address)
 
         # start communication threads
-        self._ethbrigde = _EthBrigdeClient(
+        self._ethbrigde = ethbridgeclient(
             ip_address=ip_address, use_general=False)
         self._ethbrigde.threads_start()
 


### PR DESCRIPTION
This is a companion PR of https://github.com/lnls-sirius/machine-applications/pull/205:

- Move `EthBridgeClient` import to _machine_applications_, keeping _siriuspy_ free of hardware communication protocols other than EPICS.
- Change `requirements.txt` versioning conditionals in order to delegate precise control to _ansible_ configuration.