### PR TITLE
Add auto_mon option do Devices class init

### DIFF
--- a/siriuspy/siriuspy/devices/device.py
+++ b/siriuspy/siriuspy/devices/device.py
@@ -21,10 +21,6 @@ class Device:
 
     def __init__(self, devname, properties, auto_mon=False):
         """."""
-        # TODO: It takes ~ 20ms to get an -Mon PV update when auto_mon=False
-        # We should test switching default to True.
-        # This might have a positive impact in StrengthConv!
-
         self._properties = properties[:]
         self._auto_mon = auto_mon
         self._devname, self._pvs = self._create_pvs(devname)
@@ -184,12 +180,12 @@ class DeviceApp(Device):
     This kind of device groups properties of other devices.
     """
 
-    def __init__(self, properties, devname=None):
+    def __init__(self, properties, devname=None, auto_mon=False):
         """."""
         self._devname_app = devname
 
         # call base class constructor
-        super().__init__(None, properties=properties)
+        super().__init__(None, properties=properties, auto_mon=auto_mon)
 
     @property
     def devname(self):

--- a/siriuspy/siriuspy/devices/psconv.py
+++ b/siriuspy/siriuspy/devices/psconv.py
@@ -10,6 +10,9 @@ from .syncd import DevicesSync as _DevicesSync
 class PSProperty(_DevicesSync):
     """Power Supply Epics Connector."""
 
+    # TODO: Test changing default value of auto_mon to see if conversion
+    # IOCs are improved.
+
     _ps2devs = {
         # devices which are mapped to more than one device
         'BO-Fam:PS-B-1': ('BO-Fam:PS-B-1', 'BO-Fam:PS-B-2'),
@@ -18,7 +21,7 @@ class PSProperty(_DevicesSync):
         'SI-Fam:PS-B1B2-2': ('SI-Fam:PS-B1B2-1', 'SI-Fam:PS-B1B2-2'),
         }
 
-    def __init__(self, devname, propty):
+    def __init__(self, devname, propty, auto_mon=False):
         """."""
         devname = _SiriusPVName(devname)
 
@@ -27,7 +30,7 @@ class PSProperty(_DevicesSync):
 
         # call base class constructor
         super().__init__(
-            devnames=devnames, propty_sync=[propty])
+            devnames=devnames, propty_sync=[propty], auto_mon=auto_mon)
 
     @property
     def property_sync(self):

--- a/siriuspy/siriuspy/devices/syncd.py
+++ b/siriuspy/siriuspy/devices/syncd.py
@@ -8,7 +8,7 @@ class DevicesSync(_DeviceApp):
 
     def __init__(
             self, devnames, propty_sync, propty_async=None,
-            devname=None):
+            devname=None, auto_mon=False):
         """."""
         self._devnames = devnames
         self._props_sync = list(propty_sync)
@@ -18,7 +18,7 @@ class DevicesSync(_DeviceApp):
         properties, self._prop2prop = self._get_properties()
 
         # call base class constructor
-        super().__init__(properties, devname)
+        super().__init__(properties, devname, auto_mon)
 
     @property
     def devnames(self):


### PR DESCRIPTION
While running tests with ID feedforward classes I realized that _-Mon_ PVs, for which original _Devices_ class turns `auto_mon` to False by default, were taking at least 20 ms in `PV.get`method. Here I added the option of  `auto_mon` to the class init. If set to True, `-Mon` PVs will also be created with  `auto_mon` on.

@fernandohds564 , are you using `auto_mon=False` for PVs in SOFB ? Did you not notice performance degradation?

ps: I just realized that the delay of 20 ms might be due to a test client running across a VPN connection...