### PR TITLE
Delete bogus print line in prucontroller

### DIFF
--- a/siriuspy/siriuspy/pwrsupply/pructrl/prucontroller.py
+++ b/siriuspy/siriuspy/pwrsupply/pructrl/prucontroller.py
@@ -669,7 +669,6 @@ class PRUController:
                         function_id=function_id,
                         data_len=len(data[dev_id]),
                         data_type=type(data[dev_id]),
-                        data_int=int(data[dev_id]),
                         data=data[dev_id])
         except _SerialError:
             return None


### PR DESCRIPTION
Remove a print option that was preventing diagnostics to be printed when a power supply responded with errors, in certain situations.