### PR TITLE
ENH Devices: SOFB and Device

### DIFF
--- a/siriuspy/siriuspy/devices/device.py
+++ b/siriuspy/siriuspy/devices/device.py
@@ -44,6 +44,11 @@ class Device:
         return sims
 
     @property
+    def pvs(self):
+        """Return device PVs."""
+        return self._pvs
+
+    @property
     def pvnames(self):
         """Return device PV names."""
         pvnames = {pv.pvname for pv in self._pvs.values()}

--- a/siriuspy/siriuspy/devices/device.py
+++ b/siriuspy/siriuspy/devices/device.py
@@ -44,11 +44,6 @@ class Device:
         return sims
 
     @property
-    def pvs(self):
-        """Return device PVs."""
-        return self._pvs
-
-    @property
     def pvnames(self):
         """Return device PV names."""
         pvnames = {pv.pvname for pv in self._pvs.values()}
@@ -76,9 +71,9 @@ class Device:
         for pvobj in self._pvs.values():
             pvobj.get()
 
-    def pv_object(self, propty):
+    def pv_object(self, propty=None):
         """Return PV object for a given device property."""
-        return self._pvs[propty]
+        return self._pvs[propty] if propty else self._pvs
 
     def pv_attribute_values(self, attribute):
         """Return property-value dict of a given attribute for all PVs."""

--- a/siriuspy/siriuspy/devices/sofb.py
+++ b/siriuspy/siriuspy/devices/sofb.py
@@ -42,7 +42,8 @@ class SOFB(_Device):
         # properties used only for ring-type accelerators:
         'SlowOrbX-Mon', 'SlowOrbY-Mon',
         'MTurnSum-Mon', 'MTurnOrbX-Mon', 'MTurnOrbY-Mon',
-        'MTurnIdxOrbX-Mon', 'MTurnIdxOrbY-Mon', 'MTurnIdxSum-Mon')
+        'MTurnIdxOrbX-Mon', 'MTurnIdxOrbY-Mon', 'MTurnIdxSum-Mon'
+        'MTurnTime-Mon')
 
     _default_timeout = 10  # [s]
     _off, _on = 0, 1
@@ -111,6 +112,11 @@ class SOFB(_Device):
     def mt_sum(self):
         """."""
         return self['MTurnSum-Mon'] if self.data.isring else None
+
+    @property
+    def mt_time(self):
+        """."""
+        return self['MTurnTime-Mon'] if self.data.isring else None
 
     @property
     def mt_trajx_idx(self):


### PR DESCRIPTION
- Add `MTTime-Mon` PV to get timestamp from SOFB
- Add `pvs` property to avoid dealing with private attributes. The motivation was the need for adding callbacks to pvs.