### PR TITLE
TIM.BUG: Do not update PVs when RF changes.

### DIFF
--- a/siriuspy/siriuspy/timesys/ll_classes.py
+++ b/siriuspy/siriuspy/timesys/ll_classes.py
@@ -166,13 +166,6 @@ class _BaseLL(_Callback):
                                 timeout=_CONN_TIMEOUT) or self._base_freq
         self.base_del = 1 / self._base_freq / _US2SEC
         self._rf_del = self.base_del / 5
-        # Trigger update of Delay and Duration PVs.
-        for pv in self._writepvs.values():
-            if 'DelayRaw' in pv.pvname or 'Width' in pv.pvname:
-                self._on_change_pv_thread(pv.pvname, pv.value)
-        for pv in self._readpvs.values():
-            if 'DelayRaw' in pv.pvname or 'Width' in pv.pvname:
-                self._on_change_pv_thread(pv.pvname, pv.value)
 
     def _define_convertion_prop2pv(self):
         """Define a dictionary for convertion of names.


### PR DESCRIPTION
These updates are not necessary anymore.
Now the raw PVs are in the `global_config`, not the time unit ones.
This update was creating a large and unnecessary amount of data in archiver.