### PR TITLE
Improve sofb performance

### DIFF
--- a/siriuspy/siriuspy/sofb/csdev.py
+++ b/siriuspy/siriuspy/sofb/csdev.py
@@ -62,7 +62,7 @@ class ConstTLines(_csdev.Const):
     TINY_KICK = 1e-3  # [urad]
     DEF_MAX_ORB_DISTORTION = 200  # [um]
     MAX_TRIGMODE_RATE = 2  # [Hz]
-    MIN_SLOWORB_RATE = 30  # [Hz]
+    MIN_SLOWORB_RATE = 60  # [Hz]
     BPMsFreq = 25.14  # [Hz]
 
     EnbldDsbld = _csdev.Const.register('EnbldDsbld', _et.DSBLD_ENBLD)

--- a/siriuspy/siriuspy/sofb/orbit.py
+++ b/siriuspy/siriuspy/sofb/orbit.py
@@ -102,8 +102,7 @@ class EpicsOrbit(BaseOrbit):
         self.new_orbit = _Event()
         if self.acc == 'SI':
             self._processes = []
-            self._mypipes = []
-            self._create_processes(nrprocs=4)
+            self._create_processes(nrprocs=16)
         self._orbit_thread = _Repeat(
             1/self._acqrate, self._update_orbits, niter=0)
         self._orbit_thread.start()

--- a/siriuspy/siriuspy/sofb/orbit.py
+++ b/siriuspy/siriuspy/sofb/orbit.py
@@ -32,6 +32,7 @@ def run_subprocess_old(pvs, send_pipe, recv_pipe):
 
     def callback(*_, **kwargs):
         pvo = kwargs['cb_info'][1]
+        # pvo._args['timestamp'] = _time.time()
         pvo.event.set()
 
     pvsobj = []
@@ -50,6 +51,7 @@ def run_subprocess_old(pvs, send_pipe, recv_pipe):
         for pvo in pvsobj:
             if pvo.connected and pvo.event.wait(timeout=tout):
                 tout = timeout
+                # out.append(pvo.timestamp)
                 out.append(pvo.value)
             else:
                 out.append(_np.nan)
@@ -69,6 +71,7 @@ def run_subprocess(pvs, send_pipe, recv_pipe):
 
     def callback(*_, **kwargs):
         pvo = kwargs['cb_info'][1]
+        # pvo._args['timestamp'] = _time.time()
         tstamps[pvo.index] = pvo.timestamp
         maxi = _np.nanmax(tstamps)
         mini = _np.nanmin(tstamps)
@@ -105,6 +108,7 @@ def run_subprocess(pvs, send_pipe, recv_pipe):
             if not pvo.connected:
                 out.append(_np.nan)
                 continue
+            # out.append(pvo.timestamp)
             out.append(pvo.value)
         out.append(nok)
         send_pipe.send(out)
@@ -338,6 +342,9 @@ class EpicsOrbit(BaseOrbit):
             self._update_log(msg)
             _log.error(msg[5:])
             orbx, orby = refx, refy
+        # # for tests:
+        # orbx -= _time.time()
+        # orby -= _time.time()
         return _np.hstack([orbx-refx, orby-refy])
 
     def _get_orbit_online(self, orbs):

--- a/siriuspy/siriuspy/sofb/orbit.py
+++ b/siriuspy/siriuspy/sofb/orbit.py
@@ -194,6 +194,9 @@ class EpicsOrbit(BaseOrbit):
 
     def shutdown(self):
         """."""
+        self._orbit_thread.resume()
+        self._orbit_thread.stop()
+        self._orbit_thread.join()
         if self.acc == 'SI':
             for pipe in self._mypipes_send:
                 pipe.send(False)

--- a/siriuspy/siriuspy/sofb/performance_tests/orbit_times.py
+++ b/siriuspy/siriuspy/sofb/performance_tests/orbit_times.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python-sirius
+
+import os
+os.environ['OMP_NUM_THREADS'] = '2'
+
+import time
+import numpy as np
+from threading import Event
+import signal
+
+from siriuspy.sofb.orbit import EpicsOrbit
+
+
+def calc_values(value):
+    return dict(
+        ave=value.mean(),
+        maxi=value.max(),
+        mini=value.min(),
+        std=value.std())
+
+
+def shutdown(signum, frame):
+    global evt
+    evt.set()
+
+
+evt = Event()
+signal.signal(signal.SIGINT, shutdown)
+signal.signal(signal.SIGTERM, shutdown)
+
+tmpl = '{:^18s} '*4 + '\n'
+with open('orbx.txt', 'w') as fil:
+    fil.write(tmpl.format('# avg', 'std', 'max', 'min'))
+
+with open('orby.txt', 'w') as fil:
+    fil.write(tmpl.format('# avg', 'std', 'max', 'min'))
+
+print('creating orbit object...')
+orbit = EpicsOrbit('SI')
+orbit.set_orbit_acq_rate(30)
+time.sleep(15)
+print('setting SlowOrb mode...')
+orbit.set_orbit_mode(orbit._csorb.SOFBMode.SlowOrb)
+time.sleep(5)
+
+print('starting acquisition')
+tmpl = '{ave:18.9f} {std:18.9f} {maxi:18.9f} {mini:18.9f}\n'
+cnt = 0
+while not evt.is_set():
+    orb = orbit.get_orbit(synced=True)
+    orb *= -1
+    datax = calc_values(orb[:160])
+    datay = calc_values(orb[160:])
+    with open('orbx.txt', 'a') as fil:
+        fil.write(tmpl.format(**datax))
+    with open('orby.txt', 'a') as fil:
+        fil.write(tmpl.format(**datay))
+    cnt += 1
+    if cnt > 35 * 60 * 25:
+        break
+
+orbit.shutdown()

--- a/siriuspy/siriuspy/sofb/performance_tests/orbit_times_short_term.py
+++ b/siriuspy/siriuspy/sofb/performance_tests/orbit_times_short_term.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python-sirius
+
+import os
+os.environ['OMP_NUM_THREADS'] = '2'
+
+import time
+import numpy as np
+from threading import Event
+import signal
+
+from siriuspy.sofb.orbit import EpicsOrbit
+
+
+def calc_values(value):
+    return dict(
+        ave=value.mean(),
+        maxi=value.max(),
+        mini=value.min(),
+        std=value.std())
+
+
+def shutdown(signum, frame):
+    global evt
+    evt.set()
+
+
+evt = Event()
+signal.signal(signal.SIGINT, shutdown)
+signal.signal(signal.SIGTERM, shutdown)
+
+print('creating orbit object...')
+orbit = EpicsOrbit('SI')
+orbit.set_orbit_acq_rate(30)
+time.sleep(15)
+print('setting SlowOrb mode...')
+orbit.set_orbit_mode(orbit._csorb.SOFBMode.SlowOrb)
+time.sleep(5)
+
+print('starting acquisition')
+tmpl = '{ave:18.9f} {std:18.9f} {maxi:18.9f} {mini:18.9f}\n'
+cnt = 0
+orbs = []
+while not evt.is_set():
+    t0 = time.time()
+    orbs.append(orbit.get_orbit(synced=True))
+    cnt += 1
+    print(f'dt = {(time.time()-t0)*1000:.2f} ms')
+    if cnt > 40 * 25:
+        break
+
+np.savetxt('orb.txt', orbs)
+
+orbit.shutdown()


### PR DESCRIPTION
Hi guys, I think I have found a huge source of latency in SOFB code.
This PR fixes it.

Look how is the latency of today's master branch:
![image](https://user-images.githubusercontent.com/5638331/90198683-bcccbd00-dda8-11ea-83d7-09701d5a0aa9.png)

And this is the latency of the HEAD of this branch:
![image](https://user-images.githubusercontent.com/5638331/90198737-f0a7e280-dda8-11ea-872c-7e56551d4297.png)

I didn't test the code that's running today (v2.9.0) but I'm almost sure it is very close to the master branch.

This latency was measured taking de difference of the BPM timestamps at the moment of the orbit formation and the time measured at the end of SOFB processing, at the very last line of the method which returns the orbit that will be used to calculate the kicks.
So this is a measure of the total latency of the network transmission, the acquisition of this data and processing of the SOFB IOC.

I'm not sure why our master branch was so bad, because I have tested this latency before (more than a month ago) and it wasn't this bad.
These remaining peaks are something to be investigated, but I think it is due to CPU load in the computer I ran the tests. The SOFB IOC and a lot of SI Correctors was running there at the same time I carried out these tests. I did this on purpose because I wanted to check how the code would behave under not ideal circumstances.

I'm curious to see our next measurement of the system latency with beam!