### PR TITLE
Fix Manaca IOC

### DIFF
--- a/siriuspy/siriuspy/meas/manaca/csdev.py
+++ b/siriuspy/siriuspy/meas/manaca/csdev.py
@@ -19,11 +19,11 @@ class Const(_csdev.Const):
     DEF_COEFX = 10.00 * 1e-3  # [mm/px] (source: Sergio Lordano from OPT)
     DEF_COEFY = 10.04 * 1e-3  # [mm/px] (source: Sergio Lordano from OPT)
     DEF_ROISIZE = 150
-    TARGETX = 372  # [px] source: Lucas Sanfelici via email
+    TARGETX = 375  # [px] source: Lucas Sanfelici via email (was 372)
     TARGETY = 720  # [px] source: Lucas Sanfelici via email
     DIST_FROM_SRC = 30.160  # [m] source: Sergio Lordano from OPT
     DEF_PROFILE = 'MNC:A:BASLER02:'
-    DEF_RATE = 2  # [Hz]
+    DEF_RATE = 5  # [Hz]
     IP_IOC = '10.31.74.45'
     PREFIX_IOC = 'SI-09SABL:AP-Manaca-MVS2:'
 

--- a/siriuspy/siriuspy/meas/manaca/main.py
+++ b/siriuspy/siriuspy/meas/manaca/main.py
@@ -151,7 +151,9 @@ class MeasParameters(_BaseClass, _Const):
         dlty *= self.image_processor.px2mmscaley * 1e-3  # mm --> m
 
         self._sofb_bumpx = -dltx / self.DIST_FROM_SRC * 1e6  # rad --> urad
-        self._sofb_bumpy = -dlty / self.DIST_FROM_SRC * 1e6  # rad --> urad
+        # NOTE: this signal asymmetry is due to the x-flip of the image and
+        # the beamline optics.
+        self._sofb_bumpy = dlty / self.DIST_FROM_SRC * 1e6  # rad --> urad
 
         self.run_callbacks('SOFBBumpX-Mon', self._sofb_bumpx)
         self.run_callbacks('SOFBBumpY-Mon', self._sofb_bumpy)


### PR DESCRIPTION
After first interaction with beamline,I noticed a few problems:
 - MEAS.MNT: update target x default position: they were asking to center the beam in 375px, not in 372px.
 - MEAS.MNT: change signal of y bump: the signal of the y bump was wrong, probably because of the x-flip of the image.


