### PR TITLE
use bottleneck package to speedup some critical numpy operations.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 numpy>=1.18
+bottleneck>=1.3.2
 pyepics>=3.4.0
 python-dateutil>=2.8.1
 requests>=2.22.0

--- a/siriuspy/siriuspy/sofb/orbit.py
+++ b/siriuspy/siriuspy/sofb/orbit.py
@@ -10,6 +10,7 @@ from multiprocessing import Pipe as _Pipe
 
 from epics import CAProcess as _Process
 import numpy as _np
+import bottleneck as _bn
 
 from .. import util as _util
 from ..diag.bpm.csdev import Const as _csbpm
@@ -73,8 +74,8 @@ def run_subprocess(pvs, send_pipe, recv_pipe):
         pvo = kwargs['cb_info'][1]
         # pvo._args['timestamp'] = _time.time()
         tstamps[pvo.index] = pvo.timestamp
-        maxi = _np.nanmax(tstamps)
-        mini = _np.nanmin(tstamps)
+        maxi = _bn.nanmax(tstamps)
+        mini = _bn.nanmin(tstamps)
         if (maxi-mini) < max_spread:
             ready_evt.set()
 
@@ -951,10 +952,10 @@ class EpicsOrbit(BaseOrbit):
             orb = self.smooth_orb[plane]
             dorb = orb - self.ref_orbs[plane]
             self.run_callbacks(f'SlowOrb{plane:s}-Mon', _np.array(orb))
-            self.run_callbacks(f'DeltaOrb{plane:s}Avg-Mon', dorb.mean())
-            self.run_callbacks(f'DeltaOrb{plane:s}Std-Mon', dorb.std())
-            self.run_callbacks(f'DeltaOrb{plane:s}Min-Mon', dorb.min())
-            self.run_callbacks(f'DeltaOrb{plane:s}Max-Mon', dorb.max())
+            self.run_callbacks(f'DeltaOrb{plane:s}Avg-Mon', _bn.nanmean(dorb))
+            self.run_callbacks(f'DeltaOrb{plane:s}Std-Mon', _bn.nanstd(dorb))
+            self.run_callbacks(f'DeltaOrb{plane:s}Min-Mon', _bn.nanmin(dorb))
+            self.run_callbacks(f'DeltaOrb{plane:s}Max-Mon', _bn.nanmax(dorb))
 
     def _get_orbit_from_processes_old(self):
         nr_bpms = self._csorb.nr_bpms


### PR DESCRIPTION
checkout these performance tests for the cases I use in the code:
```
In [1]: import numpy as np

In [2]: import bottleneck as bn

In [3]: a = np.random.rand(20)

In [4]: %timeit np.nanmax(a)
5.17 µs ± 16 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

In [5]: %timeit bn.nanmax(a)
128 ns ± 0.26 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)

In [6]: %timeit np.nanmin(a)
5.22 µs ± 150 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

In [7]: %timeit bn.nanmin(a)
126 ns ± 0.424 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)

In [8]: b = np.random.rand(320)

In [9]: %timeit b.mean()
3.04 µs ± 24.2 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

In [10]: %timeit bn.nanmean(b)
399 ns ± 1.51 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)

In [11]: %timeit b.std()
13 µs ± 17.5 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

In [12]: %timeit bn.nanstd(b)
701 ns ± 2.02 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)

In [13]: %timeit b.max()
1.64 µs ± 8.01 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)

In [14]: %timeit bn.nanmax(b)
377 ns ± 2.05 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)

In [15]: %timeit b.min()
1.68 µs ± 7.03 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)

In [16]: %timeit bn.nanmin(b)
290 ns ± 6.24 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
```

this is the bottleneck main page: https://pypi.org/project/Bottleneck/