### PR TITLE
MTurnAcquire

### DIFF
--- a/siriuspy/siriuspy/devices/sofb.py
+++ b/siriuspy/siriuspy/devices/sofb.py
@@ -41,6 +41,7 @@ class SOFB(_Device):
         'LoopState-Sts', 'LoopState-Sel',
         'SPassSum-Mon', 'SPassOrbX-Mon', 'SPassOrbY-Mon',
         # properties used only for ring-type accelerators:
+        'MTurnAcquire-Cmd',
         'SlowOrbX-Mon', 'SlowOrbY-Mon',
         'MTurnSum-Mon', 'MTurnOrbX-Mon', 'MTurnOrbY-Mon',
         'MTurnIdxOrbX-Mon', 'MTurnIdxOrbY-Mon', 'MTurnIdxSum-Mon',
@@ -330,6 +331,10 @@ class SOFB(_Device):
     def trigsample(self, value):
         """."""
         self['TrigNrSamplesPost-SP'] = int(value)
+
+    def cmd_mturn_acquire(self):
+        """."""
+        self['MTurnAcquire-Cmd'] = 1
 
     def cmd_reset(self):
         """."""

--- a/siriuspy/siriuspy/sofb/csdev.py
+++ b/siriuspy/siriuspy/sofb/csdev.py
@@ -25,6 +25,7 @@ class ETypes(_csdev.ETypes):
     SPASS_BG_CTRL = ('Acquire', 'Reset')
     SPASS_BG_STS = ('Empty', 'Acquiring', 'Acquired')
     SPASS_USE_BG = ('NotUsing', 'Using')
+    MTURN_ACQUIRE = ('Idle', 'Acquire')
     APPLY_CORR_TLINES = ('CH', 'CV', 'All')
     APPLY_CORR_SI = ('CH', 'CV', 'RF', 'All')
     SI_CORR_SYNC = ('Off', 'Event', 'Clock')
@@ -100,6 +101,7 @@ class ConstRings(ConstTLines):
 
     SOFBMode = _csdev.Const.register('SOFBMode', _et.ORB_MODE_RINGS)
     StsLblsCorr = _csdev.Const.register('StsLblsCorr', _et.STS_LBLS_CORR_RINGS)
+    MTurnAcquire = _csdev.Const.register('MTurnAcquire', _et.MTURN_ACQUIRE)
 
 
 class ConstSI(ConstRings):
@@ -698,6 +700,9 @@ class SOFBRings(SOFBTLines, ConstRings):
         for k in pvs_ring:
             db_ring[k] = _dcopy(prop)
         db_ring.update({
+            'MTurnAcquire-Cmd': {
+                'type': 'enum', 'value': 0,
+                'enums': self.MTurnAcquire._fields},
             'MTurnSyncTim-Sel': {
                 'type': 'enum', 'value': self.EnbldDsbld.Dsbld,
                 'enums': self.EnbldDsbld._fields},

--- a/siriuspy/siriuspy/sofb/orbit.py
+++ b/siriuspy/siriuspy/sofb/orbit.py
@@ -240,6 +240,7 @@ class EpicsOrbit(BaseOrbit):
         if not self.isring:
             return dbase
         dbase.update({
+            'MTurnAcquire-Cmd': self.acquire_mturn_orbit,
             'MTurnIdx-SP': self.set_orbit_multiturn_idx,
             'MTurnDownSample-SP': self.set_mturndownsample,
             'MTurnSyncTim-Sel': self.set_mturn_sync,
@@ -824,6 +825,10 @@ class EpicsOrbit(BaseOrbit):
         self.run_callbacks('MTurnDownSample-RB', val)
         Thread(target=self._prepare_mode, daemon=True).start()
         return True
+
+    def acquire_mturn_orbit(self):
+        """Acquire Multiturn data from BPMs"""
+        Thread(target=self._update_multiturn_orbits, daemon=True).start()
 
     def _wait_bpms(self):
         """."""

--- a/siriuspy/siriuspy/sofb/orbit.py
+++ b/siriuspy/siriuspy/sofb/orbit.py
@@ -863,9 +863,12 @@ class EpicsOrbit(BaseOrbit):
 
     def _load_ref_orbs(self):
         """."""
-        if _os.path.isfile(self._csorb.ref_orb_fname):
-            self.ref_orbs['X'], self.ref_orbs['Y'] = _np.loadtxt(
-                self._csorb.ref_orb_fname, unpack=True)
+        if not _os.path.isfile(self._csorb.ref_orb_fname):
+            return
+        self.ref_orbs['X'], self.ref_orbs['Y'] = _np.loadtxt(
+            self._csorb.ref_orb_fname, unpack=True)
+        self.run_callbacks('RefOrbX-RB', self.ref_orbs['X'].copy())
+        self.run_callbacks('RefOrbY-RB', self.ref_orbs['Y'].copy())
 
     def _save_ref_orbits(self):
         """."""


### PR DESCRIPTION
Add PV to acquire triggered data even when SOFB is in another mode, such as SlowOrb of Offline modes.

This option will be useful to study orbit stability even when the orbit correction loop is closed.