### PR TITLE
Reintroduce bsmp.Channel lock

### DIFF
--- a/siriuspy/siriuspy/pwrsupply/factory.py
+++ b/siriuspy/siriuspy/pwrsupply/factory.py
@@ -6,6 +6,7 @@ from copy import deepcopy as _deepcopy
 
 from ..search import PSSearch as _PSSearch
 from ..thread import DequeThread as _DequeThread
+from ..bsmp.serial import Channel as _Channel
 
 from .csdev import get_ps_propty_database as _get_ps_propty_database
 from .beaglebone import BeagleBone as _BeagleBone
@@ -42,6 +43,14 @@ class BBBFactory:
         # build dicts for grouped udc.
         psmodels, devices, freqs = \
             BBBFactory._build_udcgrouped(bbbname)
+
+        if len(psmodels) > 1:
+            # more than one psmodel under the same beagle. there will be two 
+            # PRUController objects pushing operation requests into the common 
+            # DequeThread. we have to use to lock mechanism in bsmp.Channel in 
+            # order to avoid one PRUController process thread interpreting the
+            # operation request of the other PRUController scan thread.
+            _Channel.create_lock()
 
         # power supply controllers and databases
         # dbase: a pvname-epicsdbase dictionary containing all
@@ -123,7 +132,7 @@ class BBBFactory:
 
         # get names of all udcs under a beaglebone
         udcs = _PSSearch.conv_bbbname_2_udc(bbbname)
-
+        
         psmodels, devices, freqs = dict(), dict(), dict()
         for udc in udcs:
 
@@ -137,8 +146,9 @@ class BBBFactory:
                 devices[psmodel_name] = devs
 
             # add udc psmodel
-            psmodel = _PSModelFactory.create(psmodel_name)
-            psmodels[psmodel_name] = psmodel
+            if psmodel_name not in psmodels:
+                psmodel = _PSModelFactory.create(psmodel_name)
+                psmodels[psmodel_name] = psmodel
 
             # add udc/bbb freqs
             try:

--- a/siriuspy/tests/bsmp/test_serial.py
+++ b/siriuspy/tests/bsmp/test_serial.py
@@ -106,7 +106,7 @@ class TestBSMPPackage(TestCase):
         'checksum',
         'stream',
         'calc_checksum',
-        'verify_checksum',
+        'verify_checksum'
     )
 
     def test_api(self):
@@ -167,6 +167,7 @@ class TestBSMPChannel(TestCase):
     """Test Channel class of BSMP package."""
 
     api = (
+        'LOCK',
         'pru',
         'address',
         'size_counter',
@@ -175,6 +176,7 @@ class TestBSMPChannel(TestCase):
         'write',
         'request_',
         'request',
+        'create_lock'
         )
 
     def setUp(self):


### PR DESCRIPTION
After the problem of PS IOC with the QF input stage was diagnosed and temporarily circumvented, and concomitant IOC control of the input and output stages was tried, responses to bsmp requests showed incorrect checksums.

It was then realized that Channel.Lock - that was dropped when optimizing code for PSSOFB - was still necessary for process threads in the IOC in communication topologies that require multiple PRUController objects. This lock is necessary in order to avoid mixing queries and responses from different PRUController objects' scan-and-process threads.

Currently only two power supplies (both still running with legacy firmware and IOC) have this topology: BO dipoles and BO QF. After updating dipoles firmware during machine shutdown in September, only BO QF will remain with a beagle/IOC controlling bsmp devices of more than one power supply type, requiring two PRUController objects, and thus requiring the Channel.LOCK reintroduced.