### PR TITLE
Improve sofb

### DIFF
--- a/siriuspy/siriuspy/sofb/correctors.py
+++ b/siriuspy/siriuspy/sofb/correctors.py
@@ -2,6 +2,7 @@
 
 import time as _time
 import logging as _log
+import traceback as _traceback
 
 import numpy as _np
 from PRUserial485 import EthBridgeClient
@@ -660,7 +661,7 @@ class EpicsCorrectors(BaseCorrectors):
                 self.run_callbacks('OrbLength-Mon', circ)
         except Exception as err:
             self._update_log('ERR: ' + str(err))
-            _log.error(str(err))
+            _log.error(_traceback.format_exc())
 
     def set_corrs_mode(self, value):
         """Set mode of CHs and CVs method."""

--- a/siriuspy/siriuspy/sofb/csdev.py
+++ b/siriuspy/siriuspy/sofb/csdev.py
@@ -574,6 +574,8 @@ class SOFBTLines(ConstTLines):
             'OrbStatusLabels-Cte': {
                 'type': 'string', 'count': len(self.StsLblsOrb._fields),
                 'value': self.StsLblsOrb._fields},
+            'SlowOrbTimeout-Mon': {
+                'type': 'int', 'value': 0, 'lolim': -1, 'hilim': 1001},
             })
         return self._add_prefix(dbase, prefix)
 

--- a/siriuspy/siriuspy/sofb/csdev.py
+++ b/siriuspy/siriuspy/sofb/csdev.py
@@ -588,6 +588,14 @@ class SOFBTLines(ConstTLines):
                 'type': 'float', 'count': self.MAX_RINGSZ*self.matrix_size,
                 'value': self.matrix_size*[0],
                 'unit': '(BH, BV)(um) x (CH, CV, RF)(urad, Hz)'},
+            'RespMat-Mon': {
+                'type': 'float', 'count': self.MAX_RINGSZ*self.matrix_size,
+                'value': self.matrix_size*[0],
+                'unit': '(BH, BV)(um) x (CH, CV, RF)(urad, Hz)'},
+            'InvRespMat-Mon': {
+                'type': 'float', 'count': self.MAX_RINGSZ*self.matrix_size,
+                'value': self.matrix_size*[0],
+                'unit': '(CH, CV, RF)(urad, Hz) x (BH, BV)(um)'},
             'RespMatMode-Sel': {
                 'type': 'enum', 'value': self.RespMatMode.Full,
                 'enums': self.RespMatMode._fields},
@@ -602,10 +610,6 @@ class SOFBTLines(ConstTLines):
                 'type': 'float', 'count': self.nr_svals,
                 'value': self.nr_svals*[0],
                 'unit': 'Singular values of the matrix in use'},
-            'InvRespMat-Mon': {
-                'type': 'float', 'count': self.MAX_RINGSZ*self.matrix_size,
-                'value': self.matrix_size*[0],
-                'unit': '(CH, CV, RF)(urad, Hz) x (BH, BV)(um)'},
             'CHEnblList-SP': {
                 'type': 'int', 'count': self.nr_ch, 'value': self.nr_ch*[1],
                 'unit': 'CHs used in correction'},

--- a/siriuspy/siriuspy/sofb/matrix.py
+++ b/siriuspy/siriuspy/sofb/matrix.py
@@ -109,6 +109,7 @@ class EpicsMatrix(BaseMatrix):
             return False
         self.respmat_extended = matb
         self._save_respmat(matb)
+        self.run_callbacks('RespMat-RB', list(self.respmat.ravel()))
         return True
 
     def _set_respmat(self, mat):
@@ -355,7 +356,7 @@ class EpicsMatrix(BaseMatrix):
         self.run_callbacks('InvRespMat-Mon', list(self.inv_respmat.ravel()))
         respmat_proc = _np.zeros(self.respmat.shape, dtype=float)
         respmat_proc[sel_mat] = _np.dot(uuu*singp, vvv).ravel()
-        self.run_callbacks('RespMat-RB', list(respmat_proc.ravel()))
+        self.run_callbacks('RespMat-Mon', list(respmat_proc.ravel()))
         msg = 'Ok!'
         self._update_log(msg)
         _log.info(msg)

--- a/siriuspy/siriuspy/sofb/orbit.py
+++ b/siriuspy/siriuspy/sofb/orbit.py
@@ -7,6 +7,7 @@ from functools import partial as _part
 from copy import deepcopy as _dcopy
 from threading import Lock, Thread, Event as _Event
 from multiprocessing import Pipe as _Pipe
+import traceback as _traceback
 
 from epics import CAProcess as _Process
 import numpy as _np
@@ -942,7 +943,7 @@ class EpicsOrbit(BaseOrbit):
             self.run_callbacks('BufferCount-Mon', count)
         except Exception as err:
             self._update_log('ERR: ' + str(err))
-            _log.error(str(err))
+            _log.error(_traceback.format_exc())
 
     def _update_online_orbits(self):
         """."""

--- a/siriuspy/siriuspy/sofb/orbit.py
+++ b/siriuspy/siriuspy/sofb/orbit.py
@@ -975,6 +975,8 @@ class EpicsOrbit(BaseOrbit):
 
         for plane in ('X', 'Y'):
             orb = self.smooth_orb[plane]
+            if orb is None:
+                return
             dorb = orb - self.ref_orbs[plane]
             self.run_callbacks(f'SlowOrb{plane:s}-Mon', _np.array(orb))
             self.run_callbacks(f'DeltaOrb{plane:s}Avg-Mon', _bn.nanmean(dorb))


### PR DESCRIPTION
 - Improve printing of error messages for debugging.
 - Add PV RespMat-Mon to return processed Respmat.
 - Fix source of inconvenient error message in Log-Mon PV:
     `unsupported operand type(s) for -: 'NoneType' and 'float'`

 - Remove deprecated codes for getting SlowOrb from BPMs.
 - Add PV SlowOrbTimeout-Mon to monitor timeout events in orbit formation.

