### PR TITLE
Fix the type of some variables in pwrsupply.bsmp.entities

### DIFF
--- a/siriuspy/siriuspy/pwrsupply/bsmp/entities.py
+++ b/siriuspy/siriuspy/pwrsupply/bsmp/entities.py
@@ -650,14 +650,10 @@ class EntitiesFAP_4P(EntitiesPS):
         {'eid': 97, 'waccess': False, 'count': 1, 'var_type': _Types.T_FLOAT},
         {'eid': 98, 'waccess': False, 'count': 1, 'var_type': _Types.T_FLOAT},
         {'eid': 99, 'waccess': False, 'count': 1, 'var_type': _Types.T_FLOAT},
-        {'eid': 100, 'waccess': False, 'count': 1,
-         'var_type': _Types.T_UINT32},
-        {'eid': 101, 'waccess': False, 'count': 1,
-         'var_type': _Types.T_UINT32},
-        {'eid': 102, 'waccess': False, 'count': 1,
-         'var_type': _Types.T_UINT32},
-        {'eid': 103, 'waccess': False, 'count': 1,
-         'var_type': _Types.T_UINT32},
+        {'eid': 100, 'waccess': False, 'count': 1, 'var_type': _Types.T_FLOAT},
+        {'eid': 101, 'waccess': False, 'count': 1, 'var_type': _Types.T_FLOAT},
+        {'eid': 102, 'waccess': False, 'count': 1, 'var_type': _Types.T_FLOAT},
+        {'eid': 103, 'waccess': False, 'count': 1, 'var_type': _Types.T_FLOAT},
         {'eid': 104, 'waccess': False, 'count': 1, 'var_type': _Types.T_UINT32},
         {'eid': 105, 'waccess': False, 'count': 1, 'var_type': _Types.T_UINT32},
         {'eid': 106, 'waccess': False, 'count': 1, 'var_type': _Types.T_FLOAT},
@@ -750,10 +746,10 @@ class EntitiesFAP_2P2S(EntitiesPS):
         {'eid': 95, 'waccess': False, 'count': 1, 'var_type': _Types.T_UINT32},
         {'eid': 96, 'waccess': False, 'count': 1, 'var_type': _Types.T_FLOAT},
         {'eid': 97, 'waccess': False, 'count': 1, 'var_type': _Types.T_FLOAT},
-        {'eid': 98, 'waccess': False, 'count': 1, 'var_type': _Types.T_UINT32},
-        {'eid': 99, 'waccess': False, 'count': 1, 'var_type': _Types.T_UINT32},
-        {'eid': 100, 'waccess': False, 'count': 1, 'var_type': _Types.T_UINT32},
-        {'eid': 101, 'waccess': False, 'count': 1, 'var_type': _Types.T_UINT32},
+        {'eid': 98, 'waccess': False, 'count': 1, 'var_type': _Types.T_FLOAT},
+        {'eid': 99, 'waccess': False, 'count': 1, 'var_type': _Types.T_FLOAT},
+        {'eid': 100, 'waccess': False, 'count': 1, 'var_type': _Types.T_FLOAT},
+        {'eid': 101, 'waccess': False, 'count': 1, 'var_type': _Types.T_FLOAT},
         {'eid': 102, 'waccess': False, 'count': 1, 'var_type': _Types.T_FLOAT},
         {'eid': 103, 'waccess': False, 'count': 1, 'var_type': _Types.T_FLOAT},
         {'eid': 104, 'waccess': False, 'count': 1, 'var_type': _Types.T_FLOAT},
@@ -873,6 +869,6 @@ class EntitiesFAC_2P4S_ACDC(EntitiesPS):
         {'eid': 56, 'waccess': False, 'count': 1, 'var_type': _Types.T_FLOAT},
         {'eid': 57, 'waccess': False, 'count': 1, 'var_type': _Types.T_UINT32},
         {'eid': 58, 'waccess': False, 'count': 1, 'var_type': _Types.T_UINT32},)
-        
+
 
     _ps_curves = ()


### PR DESCRIPTION
SI and TS dipoles.

Fixing according to BSMP specification: 
![Screenshot from 2020-12-16 10-03-05](https://user-images.githubusercontent.com/21130191/102352942-33600e00-3f87-11eb-8419-baec01d21b40.png)
![Screenshot from 2020-12-16 10-02-55](https://user-images.githubusercontent.com/21130191/102352945-34913b00-3f87-11eb-84d2-96b2c2892142.png)

