### PR TITLE
Add setpoint properties update when SOFBMode moves to Off

### DIFF
--- a/siriuspy/siriuspy/pwrsupply/psctrl/pscontroller.py
+++ b/siriuspy/siriuspy/pwrsupply/psctrl/pscontroller.py
@@ -82,6 +82,10 @@ class PSController:
         if pvname in self._writers:
             self._writers[pvname].execute(value)
 
+        # update all setpoint properties upon return from SOFBMode
+        if 'SOFBMode-Sel' in field and value == 0:
+            self._update_setpoints(devname)
+
         # return priority pvs
         return priority_pvs
 
@@ -90,9 +94,13 @@ class PSController:
         devid = self._devname2devid[devname]
         return self._pru_controller.check_connected(devid)
 
-    def init_setpoints(self):
+    def init_setpoints(self, devname=None):
         """Initialize controller setpoint fields."""
         for key, reader_sp in self._readers.items():
+
+            # if devname was passed, continue in case reader does not belong to device
+            if devname and devname not in key:
+                continue
 
             # ignore non-setpoint fields
             if not key.endswith(('-Sel', '-SP')):
@@ -142,6 +150,11 @@ class PSController:
             fields.add(split[-1])
         return fields
 
+    def _update_setpoints(self, devname):
+        """."""
+        self.read_all_fields(devname)
+        self.init_setpoints(devname)
+        
     @staticmethod
     def _get_readback_field(field):
         # NOTE: to be updated

--- a/siriuspy/siriuspy/pwrsupply/psctrl/pscontroller.py
+++ b/siriuspy/siriuspy/pwrsupply/psctrl/pscontroller.py
@@ -191,6 +191,10 @@ class StandardPSController(PSController):
         else:
             self._writers[pvname].execute(value)
 
+        # update all setpoint properties upon return from SOFBMode
+        if 'SOFBMode-Sel' in field and value == 0:
+            self._update_setpoints(devname)
+
         # return priority pvs
         return priority_pvs
 


### PR DESCRIPTION
1. **tested with SOFB !**
2. It updates setpoints on a device-by-device basis. The implementation requires that SOFBMode-Sel=Off be issued for all power supplies under a beaglebone, if all setpoints of all these power supplies are to be updated. (differently from just turning readouts back up again, which requires only one command issued for the all devices ina beaglebone)