### PR TITLE
Fix CurrInfo

### DIFF
--- a/siriuspy/siriuspy/currinfo/csdev.py
+++ b/siriuspy/siriuspy/currinfo/csdev.py
@@ -59,7 +59,7 @@ def get_litbts_currinfo_database(acc):
         'LI': ('LI-01:DI-ICT-1:', 'LI-01:DI-ICT-2:'),
         'TB': ('TB-02:DI-ICT:', 'TB-04:DI-ICT:'),
         'TS': ('TS-01:DI-ICT:', 'TS-04:DI-ICT:')}
-    def_db = {'type': 'float', 'value': 0.0, 'unit': 'nC', 'prec': 3}
+    def_db = {'type': 'float', 'value': 0.0, 'unit': 'nC', 'prec': 4}
     pvs = [
         'Charge-Mon', 'ChargeAvg-Mon', 'ChargeMin-Mon', 'ChargeMax-Mon',
         'ChargeStd-Mon']
@@ -68,7 +68,7 @@ def get_litbts_currinfo_database(acc):
         pvs_db.update({device+pv: _dcopy(def_db) for pv in pvs})
         pvs_db[device+'PulseCount-Mon'] = {'type': 'int', 'value': 0}
 
-    def_db = {'type': 'float', 'value': 0.0, 'unit': '%', 'prec': 3}
+    def_db = {'type': 'float', 'value': 0.0, 'unit': '%', 'prec': 2}
     pvs_db[pref + 'TranspEff-Mon'] = _dcopy(def_db)
     pvs_db[pref + 'TranspEffAvg-Mon'] = _dcopy(def_db)
     pvs_db = _csdev.add_pvslist_cte(pvs_db, prefix=pref)

--- a/siriuspy/siriuspy/currinfo/main.py
+++ b/siriuspy/siriuspy/currinfo/main.py
@@ -140,7 +140,7 @@ class _ASCurrInfoApp(_CurrInfoApp):
         std2 = float(meas[idxict2 + self.INDICES.STD]) * 1e9
         cnt2 = int(float(meas[idxict2 + self.INDICES.COUNT]))
 
-        eff = 100 * chg2/chg1
+        eff = max(100 * chg2/chg1, 110)
         effave = 100 * ave2/ave1
 
         self.run_callbacks(ict1 + ':Charge-Mon', chg1)
@@ -161,7 +161,7 @@ class _ASCurrInfoApp(_CurrInfoApp):
         self.run_callbacks(name + 'TranspEff-Mon', eff)
         self.run_callbacks(name + 'TranspEffAvg-Mon', effave)
 
-        
+
 class TSCurrInfoApp(_ASCurrInfoApp):
     """."""
 

--- a/siriuspy/siriuspy/currinfo/main.py
+++ b/siriuspy/siriuspy/currinfo/main.py
@@ -4,6 +4,7 @@ import time as _time
 from datetime import datetime as _datetime
 import logging as _log
 from copy import deepcopy as _dcopy
+from threading import Thread as _Thread
 
 import numpy as _np
 from epics import PV as _PV
@@ -371,6 +372,7 @@ class SICurrInfoApp(_CurrInfoApp):
 
         # initialize vars
         self._time0 = _time.time()
+        self._thread = None
         self._current_value = None
         self._current_13c4_value = None
         self._current_14c4_value = None
@@ -543,8 +545,19 @@ class SICurrInfoApp(_CurrInfoApp):
 
     def _callback_get_bo_curr3gev(self, value, timestamp, **kws):
         """Get BO Current3GeV-Mon and update InjEff PV."""
+        _ = value
         _ = kws
         _ = timestamp
+        self._thread = _Thread(target=self._update_injeff, daemon=True)
+        self._thread.start()
+
+    def _update_injeff(self):
+        # Sleep some time here to ensure SI DCCT will have been updated
+        _time.sleep(0.11)
+
+        # get booster current
+        bo_curr = self._bo_curr3gev_pv.value
+
         # choose current PV
         buffer = self._current_13c4_buffer \
             if self._dcct_mode == _Const.DCCT.DCCT13C4 \
@@ -558,12 +571,12 @@ class SICurrInfoApp(_CurrInfoApp):
             return
 
         # check if there is valid current in Booster
-        if value < self.CURR_THRESHOLD:
+        if bo_curr < self.CURR_THRESHOLD:
             return
 
         # calculate efficiency
         delta_curr = value_dq[-1] - _np.min(value_dq)
-        self._injeff = 100*(delta_curr/value) * self.HARMNUM_RATIO
+        self._injeff = 100*(delta_curr/bo_curr) * self.HARMNUM_RATIO
 
         # update pvs
         self.run_callbacks('InjEff-Mon', self._injeff)


### PR DESCRIPTION
 - Limit maximum Transport Efficiency in LI, TB and TS `CurrInfo` to 110% to avoid large number due to measurement errors;
 - Standardize precision of PVs.
 - Try to fix wrong BO-SI injection efficiency calculation for some pulses.