### PR TITLE
Improve Timing

### DIFF
--- a/siriuspy/siriuspy/devices/timing.py
+++ b/siriuspy/siriuspy/devices/timing.py
@@ -453,5 +453,5 @@ class Trigger(_Device):
 
     def cmd_unlock_low_level(self, timeout=3):
         """Unlock low level IOCs state."""
-        self.state = 0
+        self.lock_low_level = 0
         return self._wait('LowLvlLock-Sts', 0, timeout)

--- a/siriuspy/siriuspy/timesys/csdev.py
+++ b/siriuspy/siriuspy/timesys/csdev.py
@@ -513,8 +513,8 @@ def get_hl_trigger_database(hl_trigger, prefix=''):
 
     dic_ = {
         'type': 'float', 'unit': 'us', 'prec': 3,
-        'lolo': 0.008, 'low': 0.008, 'lolim': 0.008,
-        'hilim': 5e8, 'high': 10e8, 'hihi': 10e8}
+        'lolim': 0.008, 'low': 0.008, 'lolo': 0.008,
+        'hilim': 17e6, 'high': 17e6, 'hihi': 17e6}
     dic_.update(trig_db['Duration'])
     dbase['Duration-RB'] = _dcopy(dic_)
     dbase['Duration-SP'] = dic_
@@ -532,10 +532,12 @@ def get_hl_trigger_database(hl_trigger, prefix=''):
     dbase['NrPulses-RB'] = _dcopy(dic_)
     dbase['NrPulses-SP'] = dic_
 
+    max_dly_raw = 2123400000
+    max_dly = 17e6
     dic_ = {
         'type': 'float', 'unit': 'us', 'prec': 3, 'value': 0,
-        'lolo': 0.0, 'low': 0.0, 'lolim': 0.0,
-        'hilim': 5e8, 'high': 10e8, 'hihi': 10e8}
+        'lolim': 0.0, 'low': 0.0, 'lolo': 0.0,
+        'hilim': max_dly, 'high': max_dly, 'hihi': max_dly}
     dic_.update(trig_db['Delay'])
     dbase['Delay-RB'] = _dcopy(dic_)
     dbase['Delay-SP'] = dic_
@@ -543,31 +545,31 @@ def get_hl_trigger_database(hl_trigger, prefix=''):
     # Have to be float for spinbox to work properly
     dic_ = {
         'type': 'float', 'unit': 'hard', 'prec': 0, 'value': 0,
-        'lolo': 0.0, 'low': 0.0, 'lolim': 0.0,
-        'hilim': 2**32-1, 'high': 2**32-1, 'hihi': 2**32-1}
+        'lolim': 0.0, 'low': 0.0, 'lolo': 0.0,
+        'hilim': max_dly_raw, 'high': max_dly_raw, 'hihi': max_dly_raw}
     dic_.update(trig_db.get('DelayRaw', dict()))
     dbase['DelayRaw-RB'] = _dcopy(dic_)
     dbase['DelayRaw-SP'] = dic_
 
     dic_ = {
         'type': 'float', 'unit': 'us', 'prec': 3, 'value': 0.0,
-        'lolo': 0.0, 'low': 0.0, 'lolim': 0.0,
-        'hilim': 5e8, 'high': 10e8, 'hihi': 10e8}
+        'lolim': 0.0, 'low': 0.0, 'lolo': 0.0,
+        'hilim': max_dly, 'high': max_dly, 'hihi': max_dly}
     dbase['TotalDelay-Mon'] = dic_
 
     # Have to be float for spinbox to work properly
     dic_ = {
         'type': 'float', 'unit': 'hard', 'prec': 0, 'value': 0,
-        'lolo': 0.0, 'low': 0.0, 'lolim': 0.0,
-        'hilim': 2**32-1, 'high': 2**32-1, 'hihi': 2**32-1}
+        'lolim': 0.0, 'low': 0.0, 'lolo': 0.0,
+        'hilim': max_dly_raw, 'high': max_dly_raw, 'hihi': max_dly_raw}
     dbase['TotalDelayRaw-Mon'] = dic_
 
     siz = len(ll_trig_names)
     dic_ = {
         'type': 'float', 'unit': 'us', 'prec': 3,
         'count': siz, 'value': _np.zeros(siz),
-        'lolo': -5e8, 'low': -10e8, 'lolim': -10e8,
-        'hilim': 5e8, 'high': 10e8, 'hihi': 10e8}
+        'lolim': -max_dly, 'low': -max_dly, 'lolo': -max_dly,
+        'hilim': max_dly, 'high': max_dly, 'hihi': max_dly}
     dic_.update(trig_db.get('DeltaDelay', dict()))
     dbase['DeltaDelay-RB'] = _dcopy(dic_)
     dbase['DeltaDelay-SP'] = dic_
@@ -575,8 +577,8 @@ def get_hl_trigger_database(hl_trigger, prefix=''):
     dic_ = {
         'type': 'float', 'unit': 'hard', 'prec': 0,
         'count': siz, 'value': _np.zeros(siz),
-        'lolo': -2**31-1, 'low': -2**32-1, 'lolim': -2**32-1,
-        'hilim': 2**31-1, 'high': 2**32-1, 'hihi': 2**32-1}
+        'lolim': -max_dly_raw, 'low': -max_dly_raw, 'lolo': -max_dly_raw,
+        'hilim': max_dly_raw, 'high': max_dly_raw, 'hihi': max_dly_raw}
     dic_.update(trig_db.get('DeltaDelayRaw', dict()))
     dbase['DeltaDelayRaw-RB'] = _dcopy(dic_)
     dbase['DeltaDelayRaw-SP'] = dic_

--- a/siriuspy/siriuspy/timesys/csdev.py
+++ b/siriuspy/siriuspy/timesys/csdev.py
@@ -572,6 +572,15 @@ def get_hl_trigger_database(hl_trigger, prefix=''):
     dbase['DeltaDelay-RB'] = _dcopy(dic_)
     dbase['DeltaDelay-SP'] = dic_
 
+    dic_ = {
+        'type': 'float', 'unit': 'hard', 'prec': 0,
+        'count': siz, 'value': _np.zeros(siz),
+        'lolo': -2**31-1, 'low': -2**32-1, 'lolim': -2**32-1,
+        'hilim': 2**31-1, 'high': 2**32-1, 'hihi': 2**32-1}
+    dic_.update(trig_db.get('DeltaDelayRaw', dict()))
+    dbase['DeltaDelayRaw-RB'] = _dcopy(dic_)
+    dbase['DeltaDelayRaw-SP'] = dic_
+
     dic_ = {'type': 'enum', 'enums': _et.LOCKLL, 'value': 0}
     dbase['LowLvlLock-Sts'] = _dcopy(dic_)
     dbase['LowLvlLock-Sel'] = dic_

--- a/siriuspy/siriuspy/timesys/hl_classes.py
+++ b/siriuspy/siriuspy/timesys/hl_classes.py
@@ -252,6 +252,12 @@ class HLTrigger(_BaseHL):
             prop_name = prop_name.replace('DeltaDelay', 'Delay')
             self._update_deltadelay(value)
             value = self._hldelay + self._hldeltadelay
+        elif prop_name.startswith('DeltaDelayRaw'):
+            prop_name = prop_name.replace('DeltaDelayRaw', 'DelayRaw')
+            value *= self._ll_objs[0].base_del
+            self._update_deltadelay(value)
+            value = (self._hldelay + self._hldeltadelay)
+            value /= self._ll_objs[0].base_del
         else:
             value = len(self._ll_objs) * [value, ]
 
@@ -265,6 +271,8 @@ class HLTrigger(_BaseHL):
         fun = self._funs_combine_values.get(prop_name, self._combine_default)
         if prop_name.startswith('DeltaDelay'):
             prop_name = prop_name.replace('DeltaDelay', 'Delay')
+        if prop_name.startswith('DeltaDelayRaw'):
+            prop_name = prop_name.replace('DeltaDelayRaw', 'DelayRaw')
         if prop_name.startswith('LowLvlLock') and is_sp:
             vals = len(self._ll_objs) * [self.locked, ]
         else:
@@ -341,6 +349,7 @@ class HLTrigger(_BaseHL):
         return {
             'Status': self._combine_status,
             'DeltaDelay': self._combine_deltadelay,
+            'DeltaDelayRaw': self._combine_deltadelay,
             'Delay': self._combine_delay,
             'DelayRaw': self._combine_delay,
             'TotalDelay': self._combine_delay,


### PR DESCRIPTION
- add new properties to `Trigger` device.
- add PV `DeltaDelayRaw` to IOC.
- Fix limits of `Duration`, `Delay` and `DelayRaw` PVs to avoid erratic behaviors of low level IOCs.

I tested the IOC changes with the TB timing IOC.