### PR TITLE
Improve strengthconv

### DIFF
--- a/siriuspy/siriuspy/pwrsupply/beaglebone.py
+++ b/siriuspy/siriuspy/pwrsupply/beaglebone.py
@@ -54,7 +54,7 @@ class BeagleBone:
         self._create_dev2mirr_dev2timestamp_dict()
 
         # create strength conv epics objects
-        self._streconv, self._streconnected, self._strelims = \
+        self._streconvs, self._streconnected, self._strelims = \
             self._create_streconvs()
 
         # initialized state
@@ -116,7 +116,7 @@ class BeagleBone:
             return None
 
         if field in {'Energy-SP', 'Kick-SP', 'KL-SP', 'SL-SP'}:
-            streconv = self._streconv[devname]
+            streconv = self._streconvs[devname]
             curr = streconv.conv_strength_2_current(value)
             priority_pvs = self._controllers[devname].write(
                 devname, 'Current-SP', curr)
@@ -166,6 +166,11 @@ class BeagleBone:
             if controller not in psc_initialized:
                 controller.init_setpoints()
                 psc_initialized.add(controller)
+
+        # guarantee strengthconv PVs connected
+        for streconv in self._streconvs.values():
+            streconv.wait_for_connection()
+
         self._initialized = True
 
     # --- private methods ---
@@ -216,7 +221,7 @@ class BeagleBone:
         # t0_ = _time.time()
         if 'DCLink' in psname or psname.startswith('IT'):
             return
-        streconv = self._streconv[psname]
+        streconv = self._streconvs[psname]
         strelims = self._strelims[psname]
         mirror = self._dev2mirror[psname]
         dbase = self._databases[psname]


### PR DESCRIPTION
- Improves StrengthConv (This PR was tested in TB/TS PS and PU conversion IOCs)
- Add  `wait_for_connection` in connections for dipole/quadfam PVs used by BeagleBone `init` method.

```Python3
#!/usr/bin/env python-sirius

import time
from siriuspy.search import PSSearch
from siriuspy.devices import StrengthConv

proptype = 'Ref-Mon'
corrs = \
    PSSearch.get_psnames(dict(sec='SI', dev='CH')) + \
    PSSearch.get_psnames(dict(sec='SI', dev='CV'))

psconvs = dict()
t0 = time.time()
for corr in corrs:
    psconvs[corr] = StrengthConv(corr, proptype)
print(time.time() - t0)

```
Improvement:

before: 16.45 s
after: 1.41 s