### PR TITLE
Update Makefile

### DIFF
--- a/siriuspy/Makefile
+++ b/siriuspy/Makefile
@@ -1,6 +1,6 @@
 PACKAGE:=$(shell basename $(shell pwd))
-PREFIX=
-PIP=pip
+PREFIX ?=
+PIP ?= pip
 ifeq ($(CONDA_PREFIX),)
 	PREFIX=sudo -H
 	PIP=pip-sirius


### PR DESCRIPTION
Make possible to overwrite PIP and PREFIX variables.
Ansible "make": In order to install the package using `make` into the conda environment