### PR TITLE
Fix PSSOFB so that process doesn't crash in case of SerialError

### DIFF
--- a/siriuspy/siriuspy/pwrsupply/pssofb.py
+++ b/siriuspy/siriuspy/pwrsupply/pssofb.py
@@ -145,6 +145,7 @@ class PSConnSOFB:
     PS_PWRSTATE = _PSCStatus.PWRSTATE
     PS_OPMODE = _PSCStatus.OPMODE
     SOCKET_TIMEOUT_ERR = 255
+    SERIAL_ERR = 254
 
     def __init__(
             self, ethbridgeclnt_class, bbbnames=None, mproc=None,
@@ -414,6 +415,8 @@ class PSConnSOFB:
         except _socket_timeout:
             # update sofb_func_return indicating socket timeout
             self._sofb_func_return[indcs_sofb] = PSConnSOFB.SOCKET_TIMEOUT_ERR
+        except _SerialError:
+            self._sofb_func_return[indcs_sofb] = PSConnSOFB.SERIAL_ERR
 
         # update sofb_current_readback_ref
         current = udc.sofb_current_readback_ref_get()
@@ -895,9 +898,8 @@ class PSSOFB:
         mproc = {
             'rbref': _np.ndarray(shape, dtype=float, buffer=memoryview(rbref)),
             'ref': _np.ndarray(shape, dtype=float, buffer=memoryview(ref)),
-            'fret': _np.ndarray(shape, dtype=_np.int32,
-                                buffer=memoryview(fret)),
-            }
+            'fret': _np.ndarray(
+                shape, dtype=_np.int32, buffer=memoryview(fret))}
         psconnsofb = PSConnSOFB(
             ethbridgeclnt_class, bbbnames, mproc=mproc,
             sofb_update_iocs=sofb_update_iocs, dipoleoff=dipoleoff)

--- a/siriuspy/siriuspy/sofb/correctors.py
+++ b/siriuspy/siriuspy/sofb/correctors.py
@@ -856,13 +856,15 @@ class EpicsCorrectors(BaseCorrectors):
         rfc = self._corrs[-1]
         ref_vals = self._ref_kicks[0]
 
+        # NOTE: In case there is some problem in the return value, apart from
+        # DSP_TIMEOUT, which we consider not a fatal problem, return code
+        # error -2 so that the loop can be opened:
         res_tim = _np.ones(ref_vals.size, dtype=bool)
         res_tim[:-1] = fret != _ConstPSBSMP.ACK_DSP_TIMEOUT
         res = fret != _ConstPSBSMP.ACK_OK
         res &= res_tim[:-1]
         if _np.any(res):
-            self._print_guilty(
-                ~res, mode='prob_code', fret=fret)
+            self._print_guilty(~res, mode='prob_code', fret=fret)
             return -2
 
         curr_vals = _np.zeros(self._csorb.nr_corrs, dtype=float)


### PR DESCRIPTION
With this PR it will not be needed to restart SOFB IOC in case some PowerSupply is disconnected from the serial connection with its BBB. 

With the current version of the code, the loop will be opened and a message with the disconnected power supply will be printed to the IOC log. 
As soon as the power supply is connected again, the loop can be closed again.