### PR TITLE
Update injection efficienty calculation

### DIFF
--- a/siriuspy/siriuspy/currinfo/main.py
+++ b/siriuspy/siriuspy/currinfo/main.py
@@ -620,7 +620,7 @@ class SICurrInfoApp(_CurrInfoApp):
             return
 
         # calculate efficiency
-        self._injcurr = value_dq[-1] - value_dq.min()  # mA
+        self._injcurr = value_dq.max() - value_dq.min()  # mA
         self._injeff = 100*(self._injcurr/bo_curr) * self.HARMNUM_RATIO
 
         # calculate injected charge: 1e6 * mA / Hz = nC

--- a/siriuspy/siriuspy/currinfo/main.py
+++ b/siriuspy/siriuspy/currinfo/main.py
@@ -441,9 +441,9 @@ class SICurrInfoApp(_CurrInfoApp):
             self._prefix+'RF-Gen:GeneralFreq-RB', connection_timeout=0.05)
 
         self._current_13c4_buffer = _SiriusPVTimeSerie(
-            pv=self._current_13c4_pv, time_window=0.4, use_pv_timestamp=False)
+            pv=self._current_13c4_pv, time_window=0.5, use_pv_timestamp=False)
         self._current_14c4_buffer = _SiriusPVTimeSerie(
-            pv=self._current_14c4_pv, time_window=0.4, use_pv_timestamp=False)
+            pv=self._current_14c4_pv, time_window=0.5, use_pv_timestamp=False)
 
         self._current_13c4_pv.add_callback(self._callback_get_dcct_current)
         self._current_14c4_pv.add_callback(self._callback_get_dcct_current)


### PR DESCRIPTION
This PR counts on two commits to improve injection efficiency calculation
- Change buffer size of SiriusPVTimeSerie: increase buffer size from 0.4s to 0.5s so that a whole injection period is contemplated by the calculation. This change may lead to erroneous efficiency calculation during current ramping, since points before the penultimate injection may be present in buffer. We haven't noticed this error so far, but it is worth keep looking for it in the next few injections.
- Use maximum instead of last value in deque. This way we guarantee to get the maximum current in case we are injecting and killing the beam during injection optimizaiton studies.

Follow below some graphs showing the impact of these changes on the injection efficiency calculation on inject-kill optimization studies. The blue curves are calculated directly from archiver data, assuming the initial current of the storage ring (SR) is zero. Since the SR DCCT is not synchronized with injection, some points may have zero current, some may have intermediary current values and other ones, the peaks at every 0.5s in the graph, really reflect theinjcted current, so the efficiency calculated at these peaks are the correct ones (unless for the DCCT offset, which is not accounted for). 

The orange curves are calculated by the IOC using the old and new parameters for the algorithm. Note how the new parameters succeed to get the peaks of the  blue curve.
![image](https://user-images.githubusercontent.com/5638331/176186079-ba6d3aea-949b-4330-94a2-33df11eaa75e.png)

![image](https://user-images.githubusercontent.com/5638331/176186155-fc6da439-aacc-48f5-9851-ed1fc687d7a7.png)

Follow below the code used to make these figures:

```python3
import time

import numpy as np
import matplotlib.pyplot as mplt
mplt.rcParams.update({
    'lines.linewidth': 2, 'axes.grid': True, 'grid.alpha': 0.5, 'grid.linestyle': '--',
    'grid.linewidth': 1, 'font.size': 22,
    })

from siriuspy.clientarch import PVDataSet, Time


def plot_efficiencies(pvs, title='', xlim=None):
    time_eff = pvs[2].timestamp.copy()
    eff_ioc = pvs[2].value.copy()
    curr_3gev = pvs[1].value.copy()
    time_3gev = pvs[1].timestamp.copy()
    curr_si = pvs[0].value.copy()
    time_si = pvs[0].timestamp.copy()

    time_3gev -= time_si[0]
    time_eff -= time_si[0]
    time_si -= time_si[0]

    curr = np.interp(time_si, time_3gev, curr_3gev, left=0.0, right=0.0)

    eff_clc = curr_si/curr * 864/828


    fig, ax = mplt.subplots(1, 1, figsize=(10, 5))

    ax.plot(time_si, eff_clc*100, 'o-', label='From Data')
    ax.plot(time_eff, eff_ioc, 'o-', label='IOC')
    
    ax.set_title(title)
    ax.set_ylabel('Injection Efficiency [%]')
    ax.set_xlabel('Time [s]')
    if xlim is not None:
        ax.set_xlim(xlim)
    ax.set_ylim([-1, 101])
    fig.tight_layout()
    fig.show()


pvnames = [
    'SI-13C4:DI-DCCT:Current-Mon',
    'BO-Glob:AP-CurrInfo:Current3GeV-Mon',
    'SI-Glob:AP-CurrInfo:InjEff-Mon']
pvs = PVDataSet(pvnames)

pvs.time_start = Time(2022, 6, 27, 15, 37, 43)
pvs.time_stop = Time(2022, 6, 27, 15, 38, 39)
pvs.update()
plot_efficiencies(pvs, title='Old Parameters', xlim=[13.6, 31.5])

# pvs.time_start = Time(2022, 6, 27, 16, 8, 30)
# pvs.time_stop = Time(2022, 6, 27, 16, 9, 47)
# pvs.update()
# plot_efficiencies(pvs, title='Old Parameters')

pvs.time_start = Time(2022, 6, 27, 16, 24, 35)
pvs.time_stop = Time(2022, 6, 27, 16, 26, 7)
pvs.update()
plot_efficiencies(pvs, title='New Parameters', xlim=[13.8, 44])
```