### PR TITLE
Improve Devices

### DIFF
--- a/siriuspy/siriuspy/devices/__init__.py
+++ b/siriuspy/siriuspy/devices/__init__.py
@@ -26,7 +26,7 @@ from .rf import RFGen, ASLLRF, BORFCavMonitor, SIRFCavMonitor, RFCav, \
 from .screen import Screen
 from .sofb import SOFB
 from .syncd import DevicesSync
-from .timing import EVG, Event, Trigger
+from .timing import EVG, Event, Trigger, HLTiming
 from .tune import TuneFrac, TuneProc, Tune, TuneCorr
 
 del device, bpm, dcct, egun, ict, lillrf, modltr,

--- a/siriuspy/siriuspy/devices/bpm.py
+++ b/siriuspy/siriuspy/devices/bpm.py
@@ -997,6 +997,23 @@ class FamBPMs(_Devices):
                 return False
         return True
 
+    def set_switching_mode(self, mode='direct'):
+        """Set switching mode of BPMS.
+
+        Args:
+            mode ((str, int), optional): Desired mode, must be in
+                {'direct', 'switching', 1, 3}. Defaults to 'direct'.
+
+        Raises:
+            ValueError: When mode is not in {'direct', 'switching', 1, 3}.
+
+        """
+        if mode not in ('direct', 'switching', 1, 3):
+            raise ValueError('Value must be in ("direct", "switching", 1, 3).')
+
+        for bpm in self._devices:
+            bpm.switching_mode = mode
+
     def mturn_reset_flags(self):
         """Reset Multiturn flags to wait for a new orbit update."""
         for flag in self._mturn_flags.values():

--- a/siriuspy/siriuspy/devices/timing.py
+++ b/siriuspy/siriuspy/devices/timing.py
@@ -80,7 +80,7 @@ class EVG(_Device):
         """."""
         new_val = bool(value)
         if self.continuous_state != new_val:
-            self['ContinuousEvt-Sel'] = bool(value)
+            self['ContinuousEvt-Sel'] = int(new_val)
 
     @property
     def state_machine(self):
@@ -102,7 +102,7 @@ class EVG(_Device):
         """."""
         new_val = bool(value)
         if self.injection_state != new_val:
-            self['InjectionEvt-Sel'] = bool(value)
+            self['InjectionEvt-Sel'] = int(new_val)
 
     @property
     def injection_count_total(self):

--- a/siriuspy/siriuspy/devices/timing.py
+++ b/siriuspy/siriuspy/devices/timing.py
@@ -455,3 +455,85 @@ class Trigger(_Device):
         """Unlock low level IOCs state."""
         self.lock_low_level = 0
         return self._wait('LowLvlLock-Sts', 0, timeout)
+
+
+class HLTiming(_Devices):
+    """."""
+
+    SEARCH = _HLTimeSearch
+
+    def __init__(self):
+        """."""
+        self.evg = EVG()
+        evs = self.SEARCH.get_configurable_hl_events()
+        self.events = {ev: Event(ev) for ev in evs.keys()}
+        self.triggers = {t: Trigger(t) for t in self.SEARCH.get_hl_triggers()}
+        devs = [self.evg, ]
+        devs += list(self.events.values())
+        devs += list(self.triggers.values())
+        super().__init__('AS-Glob:TI-HLTiming', devs)
+
+    def get_triggers_events(self):
+        """."""
+        map_ = {tn: tr.source_str for tn, tr in self.triggers.items()}
+        inv_map = {ev: list() for ev in set(map_.values())}
+        for tn, ev in map_.items():
+            inv_map[ev].append(tn)
+        return inv_map
+
+    def change_triggers_source(self, trigs, new_src='Linac'):
+        """."""
+        notchanged = list()
+        for tn in trigs:
+            tr = self.triggers[tn]
+
+            if new_src not in tr.source_options:
+                print(f'{tn:25s} -> No Change: {new_src:s} is not an option.')
+                notchanged.append(tn)
+                continue
+
+            dly_newsrc = 0
+            if new_src in self.events:
+                dly_newsrc = self.events[new_src].delay_raw
+
+            dly_oldsrc = 0
+            old_src = tr.source_str
+            if old_src in self.events:
+                dly_oldsrc = self.events[old_src].delay_raw
+
+            dly = tr.delay_raw
+            delta_dly = dly_oldsrc
+            delta_dly -= dly_newsrc
+            dly += delta_dly
+            if dly < 0:
+                notchanged.append(tn)
+                print(f'{tn:25s} -> No Change: total delay not constant!')
+                continue
+
+            tr.delay_raw = dly
+            tr.source = new_src
+            print(f'{tn:25s} -> Change OK: .')
+        return notchanged
+
+    def change_event_delay(self, new_dly, event='Linac'):
+        """."""
+        if event not in self.events:
+            print(f'{event} is not a valid event!')
+            return False
+        new_dly = int(new_dly)
+        old_dly = self.events[event].delay_raw
+        dlt_dly = old_dly - new_dly
+
+        trigs = self.get_triggers_events()[event]
+        for trn in trigs:
+            dly = self.triggers[trn].delay_raw + dlt_dly
+            if dly < 0:
+                print(f'cannot change delay: {trn:s} would change!')
+                return False
+
+        for trn in trigs:
+            self.triggers[trn].delay_raw += dlt_dly
+        self.events[event].delay_raw = new_dly
+
+        print('Delay changed!')
+        return True

--- a/siriuspy/siriuspy/devices/timing.py
+++ b/siriuspy/siriuspy/devices/timing.py
@@ -3,9 +3,13 @@ import time as _time
 
 import numpy as _np
 
-from .device import Device as _Device, ProptyDevice as _ProptyDevice
+from mathphys.functions import get_namedtuple as _get_namedtuple
+
+from .device import Device as _Device, ProptyDevice as _ProptyDevice, \
+    Devices as _Devices
 from ..timesys.csdev import ETypes as _ETypes, Const as _TIConst, \
     get_hl_trigger_database as _get_hl_trigger_database
+from ..search import HLTimeSearch as _HLTimeSearch
 from ..util import get_bit as _get_bit
 
 
@@ -13,10 +17,14 @@ class EVG(_Device):
     """Device EVG."""
 
     DEVNAME = 'AS-RaMO:TI-EVG'
+    StateMachine = _get_namedtuple('StateMachine', (
+        'Initializing', 'Stopped', 'Continuous', 'Injection',
+        'Preparing_Continuous', 'Preparing_Injection',
+        'Restarting_Continuous'))
 
     _properties = (
         'InjectionEvt-Sel', 'InjectionEvt-Sts', 'UpdateEvt-Cmd',
-        'ContinuousEvt-Sel', 'ContinuousEvt-Sts',
+        'ContinuousEvt-Sel', 'ContinuousEvt-Sts', 'STATEMACHINE',
         'RepeatBucketList-SP', 'RepeatBucketList-RB',
         'BucketList-SP', 'BucketList-RB', 'BucketList-Mon',
         'BucketListLen-Mon', 'TotalInjCount-Mon', 'InjCount-Mon',
@@ -65,22 +73,36 @@ class EVG(_Device):
     @property
     def continuous_state(self):
         """."""
-        return self['ContinuousEvt-Sts']
+        return bool(self['ContinuousEvt-Sts'])
 
     @continuous_state.setter
     def continuous_state(self, value):
         """."""
-        self['ContinuousEvt-Sel'] = bool(value)
+        new_val = bool(value)
+        if self.continuous_state != new_val:
+            self['ContinuousEvt-Sel'] = bool(value)
+
+    @property
+    def state_machine(self):
+        """."""
+        return self['STATEMACHINE']
+
+    @property
+    def state_machine_str(self):
+        """."""
+        return self.StateMachine._fields[self.state_machine]
 
     @property
     def injection_state(self):
         """."""
-        return self['InjectionEvt-Sts']
+        return bool(self['InjectionEvt-Sts'])
 
     @injection_state.setter
     def injection_state(self, value):
         """."""
-        self['InjectionEvt-Sel'] = bool(value)
+        new_val = bool(value)
+        if self.injection_state != new_val:
+            self['InjectionEvt-Sel'] = bool(value)
 
     @property
     def injection_count_total(self):

--- a/siriuspy/siriuspy/search/hl_time_search.py
+++ b/siriuspy/siriuspy/search/hl_time_search.py
@@ -25,6 +25,12 @@ class HLTimeSearch:
         return _dcopy(cls._hl_events)
 
     @classmethod
+    def get_configurable_hl_events(cls):
+        """Return a dictionary with configurable high level events."""
+        cls._init()
+        return {e: c for e, c in cls._hl_events.items() if 0 < int(c[3:]) < 64}
+
+    @classmethod
     def get_hl_triggers(cls, filters=None, sorting=None):
         """Return a dictionary with high level triggers."""
         cls._init()

--- a/siriuspy/siriuspy/timesys/hl_classes.py
+++ b/siriuspy/siriuspy/timesys/hl_classes.py
@@ -4,6 +4,8 @@ import time as _time
 from functools import partial as _partial, reduce as _reduce
 from operator import or_ as _or_, and_ as _and_
 import logging as _log
+from threading import Lock as _Lock
+
 import numpy as _np
 
 from ..util import mode as _mode
@@ -63,6 +65,10 @@ class _BaseHL(_Callback):
     def connected(self):
         """."""
         return all(map(lambda x: x.connected, self._ll_objs))
+
+    def process(self):
+        """."""
+        return
 
     def wait_for_connection(self, timeout=None):
         """."""
@@ -224,14 +230,23 @@ class HLTrigger(_BaseHL):
         src_enums = src_enums['Src-Sel']['enums']
         ll_obj_names = _HLSearch.get_ll_trigger_names(hl_trigger)
 
-        self._hldelay = 0.0
-        self._hldeltadelay = _np.zeros(len(ll_obj_names))
+        self._hldelay_lock = _Lock()
+        self._hldelay = 0
+        self._hldeltadelay = _np.zeros(len(ll_obj_names), dtype=int)
 
         ll_objs = list()
         for name in ll_obj_names:
             ll_objs.append(_get_ll_trigger(
                 channel=name, source_enums=src_enums))
         super().__init__(hl_trigger + ':', ll_objs, callback=callback)
+
+    def process(self):
+        """."""
+        value = self.read('InInjTable')
+        if value is None:
+            return
+        self.run_callbacks(self._get_pv_name('InInjTable'), **value)
+        return
 
     def write(self, prop_name, value):
         """Call to set high level properties.
@@ -242,22 +257,25 @@ class HLTrigger(_BaseHL):
         if value is None:
             return False
         if prop_name.startswith('DelayRaw'):
-            self._update_delay(value * self._ll_objs[0].base_del)
-            value = (self._hldelay + self._hldeltadelay) / \
-                self._ll_objs[0].base_del
+            with self._hldelay_lock:
+                self._hldelay = int(value)
+                value = self._hldelay + self._hldeltadelay
         elif prop_name.startswith('Delay'):
-            self._update_delay(value)
-            value = self._hldelay + self._hldeltadelay
+            prop_name = prop_name.replace('Delay', 'DelayRaw')
+            with self._hldelay_lock:
+                self._hldelay = int(round(value / self._ll_objs[0].base_del))
+                value = self._hldelay + self._hldeltadelay
         elif prop_name.startswith('DeltaDelay'):
-            prop_name = prop_name.replace('DeltaDelay', 'Delay')
-            self._update_deltadelay(value)
-            value = self._hldelay + self._hldeltadelay
+            prop_name = prop_name.replace('DeltaDelay', 'DelayRaw')
+            with self._hldelay_lock:
+                value = _np.round(value / self._ll_objs[0].base_del)
+                self._update_deltadelay(value)
+                value = self._hldelay + self._hldeltadelay
         elif prop_name.startswith('DeltaDelayRaw'):
             prop_name = prop_name.replace('DeltaDelayRaw', 'DelayRaw')
-            value *= self._ll_objs[0].base_del
-            self._update_deltadelay(value)
-            value = (self._hldelay + self._hldeltadelay)
-            value /= self._ll_objs[0].base_del
+            with self._hldelay_lock:
+                self._update_deltadelay(value)
+                value = self._hldelay + self._hldeltadelay
         else:
             value = len(self._ll_objs) * [value, ]
 
@@ -298,19 +316,16 @@ class HLTrigger(_BaseHL):
 
     def _update_deltadelay(self, value):
         if not hasattr(value, '__len__'):
-            value = _np.array([value, ], dtype=float)
+            value = _np.array([value, ])
+        value = _np.array(value, dtype=int)
         if len(value) <= len(self._hldeltadelay):
             self._hldeltadelay[:len(value)] = value
         elif len(value) > len(self._hldeltadelay):
             self._hldeltadelay = value[:len(self._hldelay)]
-        mini = min(self._hldeltadelay)
+        mini = self._hldeltadelay.min()
         self._hldelay += mini
         self._hldeltadelay -= mini
         self._hldelay = 0 if self._hldelay <= 0 else self._hldelay
-        self.run_callbacks(self._get_pv_name('Delay'), value=self._hldelay)
-
-    def _update_delay(self, value):
-        self._hldelay = float(value)
 
     def _combine_status(self, values):
         status_or = _reduce(_or_, values)


### PR DESCRIPTION
This PR contains:

- Add class to control all HLTiming triggers and events with methods to change triggers source and event delays without changing the associated triggers' total delays.
- Add EVG property called `machine_state`
- Add method in `FamBPMs` class to set all BPMs switching mode.
- Add protection in EVG setters of `continuous_state` and `injection_state` to only change values when needed.