### PR TITLE
Update InjCtrl IOC for new topup procedure

### DIFF
--- a/siriuspy/siriuspy/devices/egun.py
+++ b/siriuspy/siriuspy/devices/egun.py
@@ -445,8 +445,8 @@ class EGun(_Devices, _Callback):
     """EGun device."""
 
     DEF_TIMEOUT = 10  # [s]
-    BIAS_MULTI_BUNCH = -46.0  # [V]
-    BIAS_SINGLE_BUNCH = -80.0  # [V]
+    BIAS_MULTI_BUNCH = -56.0  # [V]
+    BIAS_SINGLE_BUNCH = -100.0  # [V]
     BIAS_TOLERANCE = 1.0  # [V]
     HV_OPVALUE = 90.0  # [kV]
     HV_TOLERANCE = 1.0  # [kV]
@@ -455,7 +455,7 @@ class EGun(_Devices, _Callback):
     HV_RAMPUP_NRPTS = 15
     HV_RAMPDN_NRPTS = 6
     HV_RAMP_DURATION = 70  # [s]
-    FILACURR_OPVALUE = 1.38  # [A]
+    FILACURR_OPVALUE = 1.39  # [A]
     FILACURR_TOLERANCE = 0.20  # [A]
     FILACURR_MAXVALUE = 1.42  # [A]
     FILACURR_RAMP_NRPTS = 10

--- a/siriuspy/siriuspy/devices/injsys.py
+++ b/siriuspy/siriuspy/devices/injsys.py
@@ -520,7 +520,9 @@ class InjBOStandbyHandler(_BaseHandler):
             return [False, text, retval[1]]
 
         # update events
+        _time.sleep(1)
         self.evg.cmd_update_events()
+        _time.sleep(1)
 
         return True, '', []
 

--- a/siriuspy/siriuspy/devices/injsys.py
+++ b/siriuspy/siriuspy/devices/injsys.py
@@ -147,7 +147,7 @@ class ASPUStandbyHandler(_BaseHandler):
 
         # set pulsed magnet pulse off
         self._set_devices_propty(
-            self._pudevs, 'Pulse-Sel', _PSConst.DsblEnbl.Dsbl, wait=0.5)
+            self._pudevs, 'Pulse-Sel', _PSConst.DsblEnbl.Dsbl)
 
         # wait for pulsed magnet pulse to be off
         retval = self._wait_devices_propty(
@@ -160,7 +160,7 @@ class ASPUStandbyHandler(_BaseHandler):
 
         # set pulsed magnet power state off
         self._set_devices_propty(
-            self._pudevs, 'PwrState-Sel', _PSConst.DsblEnbl.Dsbl, wait=1)
+            self._pudevs, 'PwrState-Sel', _PSConst.DsblEnbl.Dsbl)
 
         # wait for pulsed magnet power state to be off
         retval = self._wait_devices_propty(
@@ -170,6 +170,9 @@ class ASPUStandbyHandler(_BaseHandler):
             text = 'Check for pulsed magnet PwrState to be off '\
                    'timed out without success! Verify pulsed magnets!'
             return [False, text, retval[1]]
+
+        # wait for modulators trig.out
+        _time.sleep(1)
 
         # turn modulator charge off
         self._set_devices_propty(
@@ -209,22 +212,8 @@ class ASPUStandbyHandler(_BaseHandler):
 
         devs = [dev for dev in self._pudevs if 'InjDpKckr' not in dev.devname]
 
-        # set pulsed magnet pulse on
-        self._set_devices_propty(
-            devs, 'Pulse-Sel', _PSConst.DsblEnbl.Enbl, wait=0.5)
-
-        # wait for pulsed magnet pulse to be on
-        retval = self._wait_devices_propty(
-            devs, 'Pulse-Sts', _PSConst.DsblEnbl.Enbl,
-            timeout=3, return_prob=True)
-        if not retval[0]:
-            text = 'Check for pulsed magnet Pulse to be enabled '\
-                   'timed out without success! Verify pulsed magnets!'
-            return [False, text, retval[1]]
-
         # set pulsed magnet power state on
-        self._set_devices_propty(
-            devs, 'PwrState-Sel', _PSConst.DsblEnbl.Enbl, wait=1)
+        self._set_devices_propty(devs, 'PwrState-Sel', _PSConst.DsblEnbl.Enbl)
 
         # wait for pulsed magnet power state to be on
         retval = self._wait_devices_propty(
@@ -232,6 +221,21 @@ class ASPUStandbyHandler(_BaseHandler):
             timeout=3, return_prob=True)
         if not retval[0]:
             text = 'Check for pulsed magnet PwrState to be on '\
+                   'timed out without success! Verify pulsed magnets!'
+            return [False, text, retval[1]]
+
+        # wait a moment for the PU high voltage and modulators charge
+        _time.sleep(1)
+
+        # set pulsed magnet pulse on
+        self._set_devices_propty(devs, 'Pulse-Sel', _PSConst.DsblEnbl.Enbl)
+
+        # wait for pulsed magnet pulse to be on
+        retval = self._wait_devices_propty(
+            devs, 'Pulse-Sts', _PSConst.DsblEnbl.Enbl,
+            timeout=3, return_prob=True)
+        if not retval[0]:
+            text = 'Check for pulsed magnet Pulse to be enabled '\
                    'timed out without success! Verify pulsed magnets!'
             return [False, text, retval[1]]
 

--- a/siriuspy/siriuspy/injctrl/csdev.py
+++ b/siriuspy/siriuspy/injctrl/csdev.py
@@ -202,12 +202,12 @@ def get_injctrl_propty_database():
         'TopUpNextInj-Mon': {
             'type': 'float', 'value': 0.0, 'unit': 's'},
         'TopUpNextInjRound-Cmd': {'type': 'int', 'value': 0},
-        'TopUpMaxNrPulses-SP': {
-            'type': 'int', 'value': 100, 'unit': 'pulses',
-            'lolim': 1, 'hilim': 1000},
-        'TopUpMaxNrPulses-RB': {
-            'type': 'int', 'value': 100, 'unit': 'pulses',
-            'lolim': 1, 'hilim': 1000},
+        'TopUpNrPulses-SP': {
+            'type': 'int', 'value': 1, 'unit': 'pulses',
+            'lolim': _ct.MIN_BKT, 'hilim': _ct.MAX_BKT},
+        'TopUpNrPulses-RB': {
+            'type': 'int', 'value': 1, 'unit': 'pulses',
+            'lolim': _ct.MIN_BKT, 'hilim': _ct.MAX_BKT},
         'AutoStop-Sel': {
             'type': 'enum', 'value': _ct.OffOn.Off, 'enums': _et.OFF_ON},
         'AutoStop-Sts': {

--- a/siriuspy/siriuspy/injctrl/main.py
+++ b/siriuspy/siriuspy/injctrl/main.py
@@ -591,7 +591,7 @@ class App(_Callback):
         self._callback_autostop()
         return True
 
-    def cmd_injsys_turn_on(self, value):
+    def cmd_injsys_turn_on(self, value=None, wait_finish=False):
         """Set turn on Injection System."""
         run = self._injsys_dev.is_running
         if run:
@@ -602,13 +602,16 @@ class App(_Callback):
         self.run_callbacks(
             'InjSysCmdDone-Mon', ','.join(self._injsys_dev.done))
         self._injsys_dev.cmd_turn_on(run_in_thread=True)
-        _Thread(target=self._watch_injsys, args=['on', ], daemon=True).start()
+        thr = _Thread(target=self._watch_injsys, args=['on', ], daemon=True)
+        thr.start()
+        if wait_finish:
+            thr.join()
 
         self._injsys_turn_on_count += 1
         self.run_callbacks('InjSysTurnOn-Cmd', self._injsys_turn_on_count)
         return False
 
-    def cmd_injsys_turn_off(self, value):
+    def cmd_injsys_turn_off(self, value=None, wait_finish=False):
         """Set turn off Injection System."""
         run = self._injsys_dev.is_running
         if run:
@@ -619,7 +622,10 @@ class App(_Callback):
         self.run_callbacks(
             'InjSysCmdDone-Mon', ','.join(self._injsys_dev.done))
         self._injsys_dev.cmd_turn_off(run_in_thread=True)
-        _Thread(target=self._watch_injsys, args=['off', ], daemon=True).start()
+        thr = _Thread(target=self._watch_injsys, args=['off', ], daemon=True)
+        thr.start()
+        if wait_finish:
+            thr.join()
 
         self._injsys_turn_off_count += 1
         self.run_callbacks('InjSysTurnOff-Cmd', self._injsys_turn_off_count)


### PR DESCRIPTION
This PR:
- Updates top-up procedure in InjCtrl IOC:
    - Check that RepeatBucketList is non-zero and don't turn off InjectionEvt, as RepeatBucketList now controls the number of pulses the top-up injection performs
    - Change how the bucket list is updated in top-up mode
    - Remove the deprecated TopUpMaxNrPulses PV and add TopUpNrPulses, which controls the number of pulses each injection will perform
    - Do not handle the PU pulse state at the start and stop of injection, as the injection system remains on between pulses

- Following the tests we performed last week, this PR chnage InjBOStandbyHandler cmd_turn_off method to wrap update events with wait intervals to avoid EVG strange behaviors

- Updates the delays in ASPUStandbyHandler according to new values established by Fabio (EPP)

- Updates the default filament current and bias voltage operation values in EGun device
