### PR TITLE
Improve ClientArchiver

### DIFF
--- a/siriuspy/siriuspy/machshift/macreport.py
+++ b/siriuspy/siriuspy/machshift/macreport.py
@@ -1025,7 +1025,10 @@ class MacReport:
             pvds.time_start = self._time_start
             pvds.time_stop = self._time_stop
 
-        self._update_log('Collecting archiver data...')
+        self._update_log(
+            'Collecting archiver data '
+            f'({self.time_start.get_iso8601()} to'
+            f' {self.time_stop.get_iso8601()})...')
 
         log_msg = 'Query for {0} in archiver took {1:.3f}s'
 


### PR DESCRIPTION
This PR changes ClientArchiver to ignore requests that return json decode errors. This occurs, for example, when archiver retrievel returns requests with results like [this](http://10.0.38.42/retrieval/data/getData.txt?pv=SI-Fam%3APS-Q2%3ADiagStatus-Mon&from=2022-06-01T21%3A41%3A25.571Z&to=2022-07-01T23%3A59%3A25.571Z). Also, it includes minor improvements in MacReport class.