### PR TITLE
Add bpm_names and csbpm explicit properties

### DIFF
--- a/siriuspy/siriuspy/devices/bpm.py
+++ b/siriuspy/siriuspy/devices/bpm.py
@@ -838,7 +838,7 @@ class FamBPMs(_Devices):
     @property
     def bpm_names(self):
         """Return BPM names."""
-        return self._bsmp_names
+        return self._bpm_names
 
     @property
     def csbpm(self):

--- a/siriuspy/siriuspy/devices/bpm.py
+++ b/siriuspy/siriuspy/devices/bpm.py
@@ -823,8 +823,8 @@ class FamBPMs(_Devices):
         devs = [BPM(dev, auto_mon=False) for dev in bpm_names]
 
         super().__init__(devname, devs)
-        self.bpm_names = bpm_names
-        self.csbpm = devs[0].csdata
+        self._bpm_names = bpm_names
+        self._csbpm = devs[0].csdata
         propties_to_keep = ['GEN_XArrayData', 'GEN_YArrayData']
 
         self._mturn_flags = dict()
@@ -834,6 +834,16 @@ class FamBPMs(_Devices):
                 pvo = bpm.pv_object(propty)
                 self._mturn_flags[pvo.pvname] = _Flag()
                 pvo.add_callback(self._mturn_set_flag)
+
+    @property
+    def bpm_names(self):
+        """Return BPM names."""
+        return self._bsmp_names
+
+    @property
+    def csbpm(self):
+        """Return control system BPM constants class."""
+        return self._csbpm
 
     def set_attenuation(self, value=RFFEATT_MAX, timeout=TIMEOUT):
         """."""
@@ -936,23 +946,23 @@ class FamBPMs(_Devices):
 
         """
         if acq_rate.lower().startswith('monit1'):
-            acq_rate = self.csbpm.AcqChan.Monit1
+            acq_rate = self._csbpm.AcqChan.Monit1
         elif acq_rate.lower().startswith('fofb'):
-            acq_rate = self.csbpm.AcqChan.FOFB
+            acq_rate = self._csbpm.AcqChan.FOFB
         elif acq_rate.lower().startswith('tbt'):
-            acq_rate = self.csbpm.AcqChan.TbT
+            acq_rate = self._csbpm.AcqChan.TbT
         else:
             raise ValueError(acq_rate + ' is not a valid acquisition rate.')
 
         if repeat:
-            repeat = self.csbpm.AcqRepeat.Repetitive
+            repeat = self._csbpm.AcqRepeat.Repetitive
         else:
-            repeat = self.csbpm.AcqRepeat.Normal
+            repeat = self._csbpm.AcqRepeat.Normal
 
         if external:
-            trig = self.csbpm.AcqTrigTyp.External
+            trig = self._csbpm.AcqTrigTyp.External
         else:
-            trig = self.csbpm.AcqTrigTyp.Now
+            trig = self._csbpm.AcqTrigTyp.Now
 
         self.cmd_mturn_acq_abort()
 
@@ -973,7 +983,7 @@ class FamBPMs(_Devices):
 
         """
         for bpm in self._devices:
-            bpm.acq_ctrl = self.csbpm.AcqEvents.Abort
+            bpm.acq_ctrl = self._csbpm.AcqEvents.Abort
 
         for bpm in self._devices:
             boo = bpm.wait_acq_finish()
@@ -989,7 +999,7 @@ class FamBPMs(_Devices):
 
         """
         for bpm in self._devices:
-            bpm.acq_ctrl = self.csbpm.AcqEvents.Start
+            bpm.acq_ctrl = self._csbpm.AcqEvents.Start
 
         for bpm in self._devices:
             boo = bpm.wait_acq_start()


### PR DESCRIPTION
Improve class interface by explicitly defining properties, instead of attributes that have to be read in the code implementation.