### PR TITLE
FOFB add KickCH and KickCV

### DIFF
--- a/siriuspy/siriuspy/devices/fofb.py
+++ b/siriuspy/siriuspy/devices/fofb.py
@@ -666,6 +666,7 @@ class HLFOFB(_Device):
         'CorrSetAccFreezeEnbl-Cmd', 'CorrSetAccClear-Cmd',
         'FOFBCtrlStatus-Mon', 'FOFBCtrlSyncNet-Cmd', 'FOFBCtrlSyncRefOrb-Cmd',
         'FOFBCtrlConfTFrameLen-Cmd', 'FOFBCtrlConfBPMLogTrg-Cmd',
+        'KickBufferSize-SP', 'KickBufferSize-RB', 'KickCH-Mon', 'KickCV-Mon',
         'RefOrbX-SP', 'RefOrbX-RB', 'RefOrbY-SP', 'RefOrbY-RB',
         'GetRefOrbFromSlowOrb-Cmd',
         'BPMXEnblList-SP', 'BPMXEnblList-RB',
@@ -779,6 +780,25 @@ class HLFOFB(_Device):
         """Command to configure all BPM logical triggers related to FOFB."""
         self['FOFBCtrlConfBPMLogTrg-Cmd'] = 1
         return True
+
+    @property
+    def kick_buffer_size(self):
+        """Return kicks buffer size."""
+        return self['KickBufferSize-RB']
+
+    @kick_buffer_size.setter
+    def kick_buffer_size(self, value):
+        self['KickBufferSize-SP'] = max(1, int(value))
+
+    @property
+    def kickch(self):
+        """Return average of CH kicks."""
+        return self['KickCH-Mon']
+
+    @property
+    def kickcv(self):
+        """Return average of CV kicks."""
+        return self['KickCV-Mon']
 
     @property
     def refx(self):

--- a/siriuspy/siriuspy/devices/pwrsupply.py
+++ b/siriuspy/siriuspy/devices/pwrsupply.py
@@ -120,27 +120,32 @@ class _PSDev(_Device):
 
     @property
     def strength_property(self):
-        """."""
+        """Return Strength name."""
         return self._strength_propty
 
     @property
     def strength_units(self):
-        """."""
+        """Return Strength units."""
         return self._strength_units
 
     @property
     def strength(self):
-        """."""
+        """Return Strength RB."""
         return self[self._strength_rb_propty]
 
     @strength.setter
     def strength(self, value):
-        """."""
+        """Set Strength SP."""
         self[self._strength_sp_propty] = value
 
     @property
+    def strengthref_mon(self):
+        """Return Strength Ref-Mon."""
+        return self[self._strength_propty + 'Ref-Mon']
+
+    @property
     def strength_mon(self):
-        """."""
+        """Return Strength Mon."""
         return self[self._strength_mon_propty]
 
     @property
@@ -206,6 +211,9 @@ class _PSDev(_Device):
             strength_rb_propty,
             strength_mon_propty,
         )
+        if not self._is_linac and not self._is_pulsed:
+            strengthref_mon_propty = self._strength_propty + 'Ref-Mon'
+            properties += (strengthref_mon_propty, )
 
         ret = (
             strength_sp_propty, strength_rb_propty, strength_mon_propty,

--- a/siriuspy/siriuspy/fofb/csdev.py
+++ b/siriuspy/siriuspy/fofb/csdev.py
@@ -161,7 +161,7 @@ class HLFOFBConst(_csdev.Const):
                 'type': 'float', 'unit': 'urad', 'count': self.nr_ch,
                 'value': self.nr_ch*[0]},
             'KickCV-Mon': {
-                'type': 'float', 'unit': 'um', 'count': self.nr_cv,
+                'type': 'float', 'unit': 'urad', 'count': self.nr_cv,
                 'value': self.nr_cv*[0]},
 
             # Reference Orbit (same order os SOFB)

--- a/siriuspy/siriuspy/fofb/csdev.py
+++ b/siriuspy/siriuspy/fofb/csdev.py
@@ -41,6 +41,7 @@ class HLFOFBConst(_csdev.Const):
     MIN_SING_VAL = 0.2
     TIKHONOV_REG_CONST = 0
     SINGVALHW_THRS = 1e-14
+    DEF_KICK_BUFFER_SIZE = 5
 
     CONV_UM_2_NM = 1e3
     ACCGAIN_RESO = 2**-12
@@ -146,6 +147,22 @@ class HLFOFBConst(_csdev.Const):
             'FOFBCtrlSyncRefOrb-Cmd': {'type': 'int', 'value': 0},
             'FOFBCtrlConfTFrameLen-Cmd': {'type': 'int', 'value': 0},
             'FOFBCtrlConfBPMLogTrg-Cmd': {'type': 'int', 'value': 0},
+
+            # Kicks and Kick buffer configuration:
+            'KickBufferSize-SP': {
+                'type': 'float', 'value': self.DEF_KICK_BUFFER_SIZE, 'prec': 0,
+                'lolim': 1, 'hilim': 1000,
+                'unit': 'Size of the buffer to calculate kicks average.'},
+            'KickBufferSize-RB': {
+                'type': 'float', 'value': self.DEF_KICK_BUFFER_SIZE, 'prec': 0,
+                'lolim': 1, 'hilim': 1000,
+                'unit': 'Size of the buffer to calculate kicks average.'},
+            'KickCH-Mon': {
+                'type': 'float', 'unit': 'urad', 'count': self.nr_ch,
+                'value': self.nr_ch*[0]},
+            'KickCV-Mon': {
+                'type': 'float', 'unit': 'um', 'count': self.nr_cv,
+                'value': self.nr_cv*[0]},
 
             # Reference Orbit (same order os SOFB)
             'RefOrbX-SP': {

--- a/siriuspy/siriuspy/fofb/main.py
+++ b/siriuspy/siriuspy/fofb/main.py
@@ -97,7 +97,7 @@ class App(_Callback):
         self._kick_buffer_size = self._const.DEF_KICK_BUFFER_SIZE
         for idx, pso in enumerate(self._corrs_dev._psdevs):
             self._kick_buffer.append([])
-            pso.pv_object('CurrentRef-Mon').add_callback(
+            pso.pv_object('KickRef-Mon').add_callback(
                 _part(self._update_kick_buffer, ps_index=idx))
 
         self._rf_dev = _RFGen()
@@ -464,8 +464,7 @@ class App(_Callback):
         _ = kwargs, pvname
         if value is None:
             return
-        val = self._corrs_dev._psconv[ps_index].conv_current_2_strength(value)
-        self._kick_buffer[ps_index].append(val)
+        self._kick_buffer[ps_index].append(value)
         del self._kick_buffer[ps_index][:-self._kick_buffer_size]
 
     def _update_kicks(self):

--- a/siriuspy/siriuspy/fofb/main.py
+++ b/siriuspy/siriuspy/fofb/main.py
@@ -96,9 +96,10 @@ class App(_Callback):
         self._kick_buffer = []
         self._kick_buffer_size = self._const.DEF_KICK_BUFFER_SIZE
         for idx, pso in enumerate(self._corrs_dev._psdevs):
+            pvo = pso.pv_object('CurrentRef-Mon')
+            pvo.auto_monitor = True
             self._kick_buffer.append([])
-            pso.pv_object('KickRef-Mon').add_callback(
-                _part(self._update_kick_buffer, ps_index=idx))
+            pvo.add_callback(_part(self._update_kick_buffer, ps_index=idx))
 
         self._rf_dev = _RFGen()
 
@@ -464,7 +465,10 @@ class App(_Callback):
         _ = kwargs, pvname
         if value is None:
             return
-        self._kick_buffer[ps_index].append(value)
+        val = self._corrs_dev._psconv[ps_index].conv_current_2_strength(value)
+        if val is None:
+            return
+        self._kick_buffer[ps_index].append(val)
         del self._kick_buffer[ps_index][:-self._kick_buffer_size]
 
     def _update_kicks(self):

--- a/siriuspy/siriuspy/fofb/main.py
+++ b/siriuspy/siriuspy/fofb/main.py
@@ -465,8 +465,8 @@ class App(_Callback):
         if value is None:
             return
         val = self._corrs_dev._psconv[ps_index].conv_current_2_strength(value)
-        self._current_buffer[ps_index].append(val)
-        del self._current_buffer[ps_index][:-self._kick_buffer_size]
+        self._kick_buffer[ps_index].append(val)
+        del self._kick_buffer[ps_index][:-self._kick_buffer_size]
 
     def _update_kicks(self):
         kickch, kickcv = [], []


### PR DESCRIPTION
This PR adds PVs to expose arrays with kicks from CH and CV correctors.
The kicks are calculated from the last values of the currents of each corrector.
The number of points used in the averaging process is defined by PV `KickBufferSize-SP`.