### PR TITLE
Avoid crashing on Virtual Circuit Disconnect event

### DIFF
--- a/siriuspy/siriuspy/devices/device.py
+++ b/siriuspy/siriuspy/devices/device.py
@@ -3,7 +3,8 @@
 import time as _time
 import operator as _opr
 
-from epics.ca import ChannelAccessGetFailure as _ChannelAccessGetFailure
+from epics.ca import ChannelAccessGetFailure as _ChannelAccessGetFailure, \
+    CASeverityException as _CASeverityException
 import numpy as _np
 
 from ..envars import VACA_PREFIX as _VACA_PREFIX
@@ -123,8 +124,8 @@ class Device:
         pvobj = self._pvs[propty]
         try:
             value = pvobj.get(timeout=Device.GET_TIMEOUT)
-        except _ChannelAccessGetFailure:
-            # This is raised in a Virtual Circuit Disconnect (192)
+        except (_ChannelAccessGetFailure, _CASeverityException):
+            # exceptions raised in a Virtual Circuit Disconnect (192)
             # event. If the PV IOC goes down, for example.
             print('Could not get value of {}'.format(pvobj.pvname))
             value = None


### PR DESCRIPTION
We observed that when some power supply IOCs are restarted, some conversion IOCs such as PU Conv and Fast Corrector Conv crash with "Virtual Circuit Disconnect" event. This commit tries to handle that by also catching CASeverityException in the Device.\_\_getitem\_\_ method.

Detail, error message in fast corrector conversion IOC:
```
    Context: "10.128.212.51:45439"
    Source File: ../cac.cpp line 1237
    Current Time: Mon Oct 17 2022 18:01:51.316379358
..................................................................
CA.Client.Exception...............................................
    Warning: "Virtual circuit disconnect"
    Context: "10.128.209.50:42394"
    Source File: ../cac.cpp line 1237
    Current Time: Mon Oct 17 2022 18:01:51.330819729
..................................................................
WARNING | 2022-10-17 18:01:56 | si_ps_conv_fastcorrs.run                 [ 116] ::: [!!] - exception while processing main loop
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/dist-packages/si_ps_conv_fastcorrs/si_ps_conv_fastcorrs.py", line 114, in run
    PCAS_DRIVER.app.process()
  File "/usr/local/lib/python3.9/dist-packages/si_ps_conv_fastcorrs/main.py", line 104, in process
    self.scan_device(psname)
  File "/usr/local/lib/python3.9/dist-packages/si_ps_conv_fastcorrs/main.py", line 159, in scan_device
    curr3 = conn['-Mon'].value
  File "/usr/local/lib/python3.9/dist-packages/siriuspy/devices/psconv.py", line 40, in value
    return self.value_get(self.property_sync)
  File "/usr/local/lib/python3.9/dist-packages/siriuspy/devices/syncd.py", line 53, in value_get
    values = [self[prop] for prop in props]
  File "/usr/local/lib/python3.9/dist-packages/siriuspy/devices/syncd.py", line 53, in <listcomp>
    values = [self[prop] for prop in props]
  File "/usr/local/lib/python3.9/dist-packages/siriuspy/devices/device.py", line 125, in __getitem__
exiting...
    value = pvobj.get(timeout=Device.GET_TIMEOUT)
  File "/usr/local/lib/python3.9/dist-packages/epics/pv.py", line 481, in get
    data = self.get_with_metadata(count=count, as_string=as_string,
  File "/usr/local/lib/python3.9/dist-packages/epics/pv.py", line 48, in wrapped
    return func(self, *args, **kwargs)
  File "/usr/local/lib/python3.9/dist-packages/epics/pv.py", line 560, in get_with_metadata
    md = ca.get_with_metadata(
  File "/usr/local/lib/python3.9/dist-packages/epics/ca.py", line 620, in wrapper
    return fcn(*args, **kwds)
  File "/usr/local/lib/python3.9/dist-packages/epics/ca.py", line 1370, in get_with_metadata
    PySEVCHK('get', ret)
  File "/usr/local/lib/python3.9/dist-packages/epics/ca.py", line 644, in PySEVCHK
    raise CASeverityException(func_name, message(status))
epics.ca.CASeverityException:  get returned 'Virtual circuit disconnect'
```