### PR TITLE
Update FOFB IOC

### DIFF
--- a/siriuspy/siriuspy/devices/fofb.py
+++ b/siriuspy/siriuspy/devices/fofb.py
@@ -507,6 +507,16 @@ class FamFastCorrs(_Devices):
         return list(self._psnames)
 
     @property
+    def psdevs(self):
+        """PS device list."""
+        return self._psdevs
+
+    @property
+    def psconvs(self):
+        """PS conversion device list."""
+        return self._psconv
+
+    @property
     def pwrstate(self):
         """Power State.
 

--- a/siriuspy/siriuspy/fofb/csdev.py
+++ b/siriuspy/siriuspy/fofb/csdev.py
@@ -154,6 +154,7 @@ class HLFOFBConst(_csdev.Const):
                 'type': 'string', 'count': len(_et.STS_LBLS_CORR),
                 'value': _et.STS_LBLS_CORR},
             'CorrConfig-Cmd': {'type': 'int', 'value': 0},
+            'CorrSetPwrStateOn-Cmd': {'type': 'int', 'value': 0},
             'CorrSetOpModeManual-Cmd': {'type': 'int', 'value': 0},
             'CorrSetAccFreezeDsbl-Cmd': {'type': 'int', 'value': 0},
             'CorrSetAccFreezeEnbl-Cmd': {'type': 'int', 'value': 0},

--- a/siriuspy/siriuspy/fofb/main.py
+++ b/siriuspy/siriuspy/fofb/main.py
@@ -41,6 +41,7 @@ class App(_Callback):
         self._abort_thread = False
         self._corr_status = self._pvs_database['CorrStatus-Mon']['value']
         self._corr_confall_count = 0
+        self._corr_setpwrstateon_count = 0
         self._corr_setopmodemanual_count = 0
         self._corr_setaccfreezeenbl_count = 0
         self._corr_setaccfreezedsbl_count = 0
@@ -127,6 +128,7 @@ class App(_Callback):
             'LoopGainH-SP': _part(self.set_loopgain, 'h'),
             'LoopGainV-SP': _part(self.set_loopgain, 'v'),
             'CorrConfig-Cmd': self.cmd_corr_configure,
+            'CorrSetPwrStateOn-Cmd': self.cmd_corr_pwrstate_on,
             'CorrSetOpModeManual-Cmd': self.cmd_corr_opmode_manual,
             'CorrSetAccFreezeDsbl-Cmd': self.cmd_corr_accfreeze_dsbl,
             'CorrSetAccFreezeEnbl-Cmd': self.cmd_corr_accfreeze_enbl,
@@ -177,6 +179,8 @@ class App(_Callback):
         self.run_callbacks('LoopGainV-Mon', self._loop_gain_mon_v)
         self.run_callbacks('CorrStatus-Mon', self._corr_status)
         self.run_callbacks('CorrConfig-Cmd', self._corr_confall_count)
+        self.run_callbacks(
+            'CorrSetPwrStateOn-Cmd', self._corr_setpwrstateon_count)
         self.run_callbacks(
             'CorrSetOpModeManual-Cmd', self._corr_setopmodemanual_count)
         self.run_callbacks(
@@ -478,8 +482,23 @@ class App(_Callback):
         self.run_callbacks('CorrConfig-Cmd', self._corr_confall_count)
         return False
 
+    def cmd_corr_pwrstate_on(self, _):
+        """Set all corrector pwrstate to on."""
+        self._update_log('Received set corrector pwrstate to on...')
+        if not self._check_corr_connection():
+            return False
+
+        self._update_log('Setting all corrector pwrstate to on...')
+        self._corrs_dev.set_pwrstate(self._const.OffOn.On)
+        self._update_log('Done.')
+
+        self._corr_setpwrstateon_count += 1
+        self.run_callbacks(
+            'CorrSetPwrStateOn-Cmd', self._corr_setpwrstateon_count)
+        return False
+
     def cmd_corr_opmode_manual(self, _):
-        """Set all corrector opmode."""
+        """Set all corrector opmode to manual."""
         self._update_log('Received set corrector opmode to manual...')
         if not self._check_corr_connection():
             return False

--- a/siriuspy/siriuspy/fofb/main.py
+++ b/siriuspy/siriuspy/fofb/main.py
@@ -102,7 +102,7 @@ class App(_Callback):
 
         self._kick_buffer = []
         self._kick_buffer_size = self._const.DEF_KICK_BUFFER_SIZE
-        for idx, pso in enumerate(self._corrs_dev._psdevs):
+        for idx, pso in enumerate(self._corrs_dev.psdevs):
             pvo = pso.pv_object('CurrentRef-Mon')
             pvo.auto_monitor = True
             self._kick_buffer.append([])
@@ -688,7 +688,7 @@ class App(_Callback):
         _ = kwargs, pvname
         if value is None:
             return
-        val = self._corrs_dev._psconv[ps_index].conv_current_2_strength(value)
+        val = self._corrs_dev.psconvs[ps_index].conv_current_2_strength(value)
         if val is None:
             return
         self._kick_buffer[ps_index].append(val)


### PR DESCRIPTION
- Add auxiliary command to turn on the correctors, this is useful for the commissioning period, when IOCs are sometimes restarted and the power supplies are turned off in this process.