### PR TITLE
Add IOCSearch 

### DIFF
--- a/siriuspy/siriuspy/clientweb/implementation.py
+++ b/siriuspy/siriuspy/clientweb/implementation.py
@@ -14,6 +14,7 @@ _PSTYPES_DATA_FOLDER = '/pwrsupply/pstypes-data/'
 _DIAG_FOLDER = '/diagnostics/'
 _TIMESYS_FOLDER = '/timesys/'
 _MAC_SCHEDULE_FOLDER = '/macschedule/'
+_DOC_SERV_FOLDER = '/documentation/services/'
 
 
 def read_url(url, timeout=_TIMEOUT):
@@ -178,3 +179,16 @@ def mac_schedule_read(year, timeout=_TIMEOUT):
     """Read machine schedule data."""
     url = _MAC_SCHEDULE_FOLDER + str(year) + '.txt'
     return read_url(url, timeout=timeout)
+
+
+def doc_services_read(timeout=_TIMEOUT):
+    """Read service documentation data."""
+    url = _DOC_SERV_FOLDER
+    text = read_url(url, timeout=timeout)
+    pattern = _re.compile('"([a-zA-Z_0-9]*.yml)"')
+    files = pattern.findall(text)
+    text = ''
+    for file in files:
+        text += read_url(url + file, timeout=timeout)
+        text += '\n\n'
+    return text

--- a/siriuspy/siriuspy/search/__init__.py
+++ b/siriuspy/siriuspy/search/__init__.py
@@ -4,6 +4,7 @@ from .ps_search import PSSearch
 from .ma_search import MASearch
 from .bpms_search import BPMSearch
 from .id_search import IDSearch
+from .ioc_search import IOCSearch
 
 del hl_time_search
 del ll_time_search
@@ -11,3 +12,4 @@ del ps_search
 del ma_search
 del bpms_search
 del id_search
+del ioc_search

--- a/siriuspy/siriuspy/search/ioc_search.py
+++ b/siriuspy/siriuspy/search/ioc_search.py
@@ -1,0 +1,121 @@
+"""IOC Search module."""
+
+import re as _re
+from threading import Lock as _Lock
+import yaml as _yaml
+
+from .. import clientweb as _web
+
+
+class IOCSearch:
+    """IOC Search Class."""
+
+    _service_list = list()
+    _ioc_list = list()
+    _service_2_ioc_dict = dict()
+    _service_2_prefix_dict = dict()
+    _ioc_2_service_dict = dict()
+    _ioc_2_prefix_dict = dict()
+
+    _lock = _Lock()
+
+    @staticmethod
+    def get_services(pattern='.*'):
+        """Return a sorted and filtered list of services."""
+        IOCSearch._reload_service_2_ioc_dict()
+        pattern = _re.compile(pattern)
+        auxlist = list()
+        for serv in IOCSearch._service_list:
+            if pattern.match(serv):
+                auxlist.append(serv)
+        return auxlist
+
+    @staticmethod
+    def get_iocs(pattern='.*'):
+        """Return a sorted and filtered list of IOCs."""
+        IOCSearch._reload_service_2_ioc_dict()
+        pattern = _re.compile(pattern)
+        auxlist = list()
+        for ioc in IOCSearch._ioc_list:
+            if pattern.match(ioc):
+                auxlist.append(ioc)
+        return auxlist
+
+    @staticmethod
+    def conv_service_2_ioc(service):
+        """Return IOCs associated with a service."""
+        IOCSearch._reload_service_2_ioc_dict()
+        return IOCSearch._service_2_ioc_dict[service]
+
+    @staticmethod
+    def conv_ioc_2_service(ioc):
+        """Return service associated with an IOC."""
+        IOCSearch._reload_service_2_ioc_dict()
+        return IOCSearch._ioc_2_service_dict[ioc]
+
+    @staticmethod
+    def conv_ioc_2_prefix(ioc):
+        """Return PV prefixes associated with a ioc."""
+        IOCSearch._reload_service_2_ioc_dict()
+        return IOCSearch._ioc_2_prefix_dict[ioc]
+
+    @staticmethod
+    def conv_service_2_prefix(service):
+        """Return PV prefixes associated with a service."""
+        IOCSearch._reload_service_2_ioc_dict()
+        iocs = IOCSearch.conv_service_2_ioc(service)
+        prefixes = list()
+        for ioc in iocs:
+            pref = IOCSearch._ioc_2_prefix_dict[ioc]
+            prefixes.extend(pref)
+        return prefixes
+
+    @staticmethod
+    def conv_prefix_2_ioc(prefix_pattern):
+        """Return IOCs that match a prefix pattern."""
+        IOCSearch._reload_service_2_ioc_dict()
+        pattern = _re.compile(prefix_pattern)
+        iocs = set()
+        for ioc in IOCSearch._ioc_list:
+            prefixes = IOCSearch._ioc_2_prefix_dict[ioc]
+            for pref in prefixes:
+                if pattern.match(pref):
+                    iocs.add(ioc)
+        return iocs
+
+    @staticmethod
+    def conv_prefix_2_service(prefix_pattern):
+        """Return services that match a prefix pattern."""
+        IOCSearch._reload_service_2_ioc_dict()
+        iocs = IOCSearch.conv_prefix_2_ioc(prefix_pattern)
+        services = set()
+        for ioc in iocs:
+            serv = IOCSearch.conv_ioc_2_service(ioc)
+            services.add(serv)
+        return services
+
+    @staticmethod
+    def _reload_service_2_ioc_dict():
+        """Load service to IOC data to a dict."""
+        with IOCSearch._lock:
+            if IOCSearch._service_2_ioc_dict:
+                return
+            if not _web.server_online():
+                raise Exception(
+                    'could not read service to IOC table from web server')
+            text = _web.doc_services_read()
+            data = _yaml.load(text)
+            service_2_ioc_dict = dict()
+            ioc_2_prefixes_dict = dict()
+            for service, ioc2pref in data.items():
+                service_2_ioc_dict[service] = [ioc for ioc in ioc2pref]
+                ioc_2_prefixes_dict.update(ioc2pref)
+            IOCSearch._service_2_ioc_dict = service_2_ioc_dict
+            IOCSearch._ioc_2_prefixes_dict = ioc_2_prefixes_dict
+            IOCSearch._service_list = sorted(list(service_2_ioc_dict.keys()))
+            IOCSearch._ioc_list = sorted(list(ioc_2_prefixes_dict.keys()))
+
+            ioc_2_service_dict = dict()
+            for serv, iocs in IOCSearch._service_2_ioc_dict.items():
+                ioc_2_service_dict.update({i: serv for i in iocs})
+            IOCSearch._ioc_2_service_dict = ioc_2_service_dict


### PR DESCRIPTION
Hi guys, this PR adds the first version of a class IOCSearch (I accept suggestions for the name).
The class read the files included in control-system-constants server /documents/services folder and, for example, make it possible to:
- list and search for docker services 
- list and search for IOCs in control system
- search for IOCs and services associated with a PV prefix

