### PR TITLE
Fix SOFB

### DIFF
--- a/siriuspy/siriuspy/devices/fofb.py
+++ b/siriuspy/siriuspy/devices/fofb.py
@@ -1267,7 +1267,7 @@ class HLFOFB(_Device):
     @property
     def bpmxenbl(self):
         """BPM X enable list."""
-        return self['BPMXEnblList-RB']
+        return _np.array(self['BPMXEnblList-RB'], dtype=bool)
 
     @bpmxenbl.setter
     def bpmxenbl(self, value):
@@ -1276,7 +1276,7 @@ class HLFOFB(_Device):
     @property
     def bpmyenbl(self):
         """BPM Y enable list."""
-        return self['BPMYEnblList-RB']
+        return _np.array(self['BPMYEnblList-RB'], dtype=bool)
 
     @bpmyenbl.setter
     def bpmyenbl(self, value):
@@ -1285,7 +1285,7 @@ class HLFOFB(_Device):
     @property
     def chenbl(self):
         """CH enable list."""
-        return self['CHEnblList-RB']
+        return _np.array(self['CHEnblList-RB'], dtype=bool)
 
     @chenbl.setter
     def chenbl(self, value):
@@ -1294,7 +1294,7 @@ class HLFOFB(_Device):
     @property
     def cvenbl(self):
         """CV enable list."""
-        return self['CVEnblList-RB']
+        return _np.array(self['CVEnblList-RB'], dtype=bool)
 
     @cvenbl.setter
     def cvenbl(self, value):
@@ -1303,7 +1303,7 @@ class HLFOFB(_Device):
     @property
     def rfenbl(self):
         """Use RF in RespMat calculation."""
-        return self['UseRF-Sts']
+        return bool(self['UseRF-Sts'])
 
     @rfenbl.setter
     def rfenbl(self, value):

--- a/siriuspy/siriuspy/devices/sofb.py
+++ b/siriuspy/siriuspy/devices/sofb.py
@@ -268,7 +268,7 @@ class TLSOFB(_Device):
     @property
     def bpmxenbl(self):
         """."""
-        return self['BPMXEnblList-RB']
+        return _np.array(self['BPMXEnblList-RB'], dtype=bool)
 
     @bpmxenbl.setter
     def bpmxenbl(self, value):
@@ -278,7 +278,7 @@ class TLSOFB(_Device):
     @property
     def bpmyenbl(self):
         """."""
-        return self['BPMYEnblList-RB']
+        return _np.array(self['BPMYEnblList-RB'], dtype=bool)
 
     @bpmyenbl.setter
     def bpmyenbl(self, value):
@@ -288,7 +288,7 @@ class TLSOFB(_Device):
     @property
     def chenbl(self):
         """."""
-        return self['CHEnblList-RB']
+        return _np.array(self['CHEnblList-RB'], dtype=bool)
 
     @chenbl.setter
     def chenbl(self, value):
@@ -298,7 +298,7 @@ class TLSOFB(_Device):
     @property
     def cvenbl(self):
         """."""
-        return self['CVEnblList-RB']
+        return _np.array(self['CVEnblList-RB'], dtype=bool)
 
     @cvenbl.setter
     def cvenbl(self, value):
@@ -794,8 +794,8 @@ class SISOFB(BOSOFB):
     @property
     def rfenbl(self):
         """."""
-        dta = self._data
-        return self['RFEnbl-Sts'] if dta.acc_idx == dta.Rings.SI else None
+        if self._data.acc_idx == self._data.Rings.SI:
+            return bool(self['RFEnbl-Sts'])
 
     @rfenbl.setter
     def rfenbl(self, value):

--- a/siriuspy/siriuspy/sofb/correctors.py
+++ b/siriuspy/siriuspy/sofb/correctors.py
@@ -898,7 +898,7 @@ class EpicsCorrectors(BaseCorrectors):
         # NOTE: If the return value is zero, it might mean the corrector had a
         # problem. In this case we return -2 so the main correction loop can
         # exit and give back the control to the IOC.
-        iszero = _compare_kicks(curr_vals, 0, atol=1e-6)
+        iszero = _compare_kicks(curr_vals, 0, atol=1e-12)
         iszero_ref = _compare_kicks(ref_vals, 0)
         prob = iszero & ~(iszero_ref)
         prob &= mask  # If corrector is not in the loop, ignore it.

--- a/siriuspy/siriuspy/sofb/correctors.py
+++ b/siriuspy/siriuspy/sofb/correctors.py
@@ -898,7 +898,7 @@ class EpicsCorrectors(BaseCorrectors):
         # NOTE: If the return value is zero, it might mean the corrector had a
         # problem. In this case we return -2 so the main correction loop can
         # exit and give back the control to the IOC.
-        iszero = _compare_kicks(curr_vals, 0, atol=1e-12)
+        iszero = _np.equal(curr_vals, 0.0)
         iszero_ref = _compare_kicks(ref_vals, 0)
         prob = iszero & ~(iszero_ref)
         prob &= mask  # If corrector is not in the loop, ignore it.

--- a/siriuspy/siriuspy/sofb/main.py
+++ b/siriuspy/siriuspy/sofb/main.py
@@ -1047,7 +1047,7 @@ class SOFB(_BaseClass):
         if self._update_fofb_reforb and fofb.loop_state:
             dorb = self.matrix.estimate_orbit_variation(dkicks)
             dorb *= self._update_fofb_reforb_perc
-            # According to my understanding of SOLEIL's paper on this
+            # NOTE: According to my understanding of SOLEIL's paper on this
             # subject:
             # https://accelconf.web.cern.ch/d09/papers/mooc01.pdf
             # https://accelconf.web.cern.ch/d09/talks/mooc01_talk.pdf
@@ -1060,7 +1060,13 @@ class SOFB(_BaseClass):
             fofb.cmd_fofbctrl_syncreforb()
 
         if self._download_fofb_kicks and fofb.loop_state:
-            kicks_fofb = _np.r_[fofb.kickch, fofb.kickcv, 0]
+            # NOTE: Do not download kicks from correctors not in the loop:
+            kickch = fofb.kickch.copy()
+            kickcv = fofb.kickcv.copy()
+            kickch[~fofb.chenbl] = 0
+            kickcv[~fofb.cvenbl] = 0
+
+            kicks_fofb = _np.r_[kickch, kickcv, 0]
             dorb = _np.dot(fofb.respmat, kicks_fofb)
             # NOTE: calc_kicks return the kicks to correct dorb, which means
             # that a minus sign is already applied by this method. To negate


### PR DESCRIPTION
This PR fixes two bugs:
 - The opening of the loop due to false positives when trying to identify whether there is a problem with a corrector. Now I narrowed the interval where the code assumes there an error to 1e-12urad, before this value was 1e-6urad.
 - The download of FOFB kicks from correctors that are not in the loop. Now, only correctors in the loop will be considered in the downloading process.

It also makes the following API change to `HLFOFB` and `SOFB` devices: the properties `chenbl`, `cvenbl`, `bpmxenbl` and `bpmyenbl` return arrays of booleans instead of integers and `rfenbl` will also return a boolean, which is more compatible with the meaning of these properties.