### PR TITLE
Update cycle and IDSearch for EPU50

### DIFF
--- a/siriuspy/siriuspy/cycle/util.py
+++ b/siriuspy/siriuspy/cycle/util.py
@@ -33,7 +33,7 @@ def get_psnames(isadv=False):
              'dev': 'QS'}))
         names.extend(_PSSearch.get_psnames(
             {'sec': 'SI', 'sub': '[0-2][0-9]S(A|B|P)', 'dis': 'PS',
-             'dev': 'C(H|V)'}))
+             'dev': '(CH|CV|QS)'}))
         names.extend(_PSSearch.get_psnames(
             {'sec': 'SI', 'dis': 'PS', 'dev': 'FC.*'}))
     else:
@@ -41,6 +41,8 @@ def get_psnames(isadv=False):
             {'sec': 'SI', 'dis': 'PS', 'dev': '(B|Q.*|S.*|C.*|FC.*)'}))
 
     to_remove = _PSSearch.get_psnames({'sec': 'TS', 'idx': '(0|1E2)'})
+    to_remove.extend(_PSSearch.get_psnames(
+        {'sec': 'SI', 'sub': '10SB', 'dev': '(CH|CV|QS)'}))
     for name in to_remove:
         names.remove(name)
     return names

--- a/siriuspy/siriuspy/search/id_search.py
+++ b/siriuspy/siriuspy/search/id_search.py
@@ -22,9 +22,9 @@ class IDSearch:
         'CATERETE': 'SI-07SP:ID-APU22',
         'EMA':      'SI-08SB:ID-APU22',
         'MANACA':   'SI-09SA:ID-APU22',
-        'SABIA':    'SI-10SB:ID-Delta52',
+        'SABIA':    'SI-10SB:ID-EPU50',
         'IPE':      'SI-11SP:ID-APU58',
-        # 'PAINEIRA': 'SI-14SB:ID-???',
+        # 'PAINEIRA': 'SI-14SB:ID-WIG180',
         # 'SAPUCAIA': 'SI-17SA:ID-???',
     }
     _idname2beamline = {v: k for k, v in _beamline2idname.items()}


### PR DESCRIPTION
This PR:
- Removes new EPU50 feedforward correctors from cycle procedure
- Updates IDSearch with new devices (WIG180 and EPU50)