### PR TITLE
Update InjCtrl IOC

### DIFF
--- a/siriuspy/siriuspy/devices/injsys.py
+++ b/siriuspy/siriuspy/devices/injsys.py
@@ -742,6 +742,27 @@ class InjSysStandbyHandler(_Devices):
         """Turn off."""
         return self._command_base('off', run_in_thread)
 
+    def get_dev_state(self, devnames):
+        """
+        Return the state, on (True) or off (False), for each device in
+        devnames.
+
+        Parameters
+        ----------
+        devnames: list [str]
+            A list of strings with the names of the handler devices
+
+        Returns
+        -------
+        states: list [bool]
+            A list of booleans with the state of each handler devices
+        """
+        states = list()
+        for devname in devnames:
+            dev = self._dev_refs[devname]
+            states.append(dev.is_on)
+        return states
+
     # --- private methods ---
 
     def _command_base(self, cmmtype, run_in_thread):

--- a/siriuspy/siriuspy/devices/injsys.py
+++ b/siriuspy/siriuspy/devices/injsys.py
@@ -87,8 +87,6 @@ class ASPUStandbyHandler(_BaseHandler):
             self._on_values[mdev] = {
                 'CHARGE': _TIConst.DsblEnbl.Enbl,
                 'TRIGOUT': _TIConst.DsblEnbl.Enbl,
-                'TRIG_Norm': 1,
-                'Pulse_Current': 1,
                 'CPS_ALL': 1,
             }
         self._on_values[self._limps] = {

--- a/siriuspy/siriuspy/diagsys/lidiag/csdev.py
+++ b/siriuspy/siriuspy/diagsys/lidiag/csdev.py
@@ -14,7 +14,8 @@ class ETypes(_csdev.ETypes):
         'Feedback Off',
         'Amp-(SP|RB) are different',
         'Phase-(SP|RB) are different',
-        'IxQ (SP|Mon) are different')
+        'IxQ (SP|Mon) are different',
+    )
 
     DIAG_STATUS_LABELS_PU = (
         'Disconnected',
@@ -34,18 +35,23 @@ class ETypes(_csdev.ETypes):
         'TRIG_Norm not ok',
         'Pulse_Current not ok',
         'Voltage-(SP|RB) are different',
-        'Current-(SP|RB) are different')
+        'Current-(SP|RB) are different',
+        'CHARGE is off',
+        'TRIGOUT is off',
+    )
 
     DIAG_STATUS_LABELS_EG_HVPS = (
         'Disconnected',
         'Swicth Status Off',
         'Enable Status Off',
-        'Voltage (SP|Mon) are different')
+        'Voltage (SP|Mon) are different',
+    )
 
     DIAG_STATUS_LABELS_EG_FILA = (
         'Disconnected',
         'Swicth Status Off',
-        'Current-(SP|Mon) are different')
+        'Current-(SP|Mon) are different',
+    )
 
 
 _et = ETypes  # syntactic sugar

--- a/siriuspy/siriuspy/diagsys/lidiag/main.py
+++ b/siriuspy/siriuspy/diagsys/lidiag/main.py
@@ -96,7 +96,9 @@ class LIDiagApp(_App):
             self.pvs.append(pvo)
 
             # DiagStatus-Mon
-            pvs = [None]*17
+            pvs = [None]*19
+            pvs[_LIPUStatusPV.PV.CHARGES] = prefliname + ':CHARGE'
+            pvs[_LIPUStatusPV.PV.TRIGOUT] = prefliname + ':TRIGOUT'
             pvs[_LIPUStatusPV.PV.RUNSTOP] = prefliname + ':Run/Stop'
             pvs[_LIPUStatusPV.PV.PREHEAT] = prefliname + ':PreHeat'
             pvs[_LIPUStatusPV.PV.CHRALLW] = prefliname + ':Charge_Allowed'

--- a/siriuspy/siriuspy/injctrl/csdev.py
+++ b/siriuspy/siriuspy/injctrl/csdev.py
@@ -69,6 +69,8 @@ class Const(_csdev.Const):
     INJSYS_DEF_ON_ORDER = ['bo_rf', 'as_pu', 'bo_ps', 'injbo', 'li_rf']
     INJSYS_DEF_OFF_ORDER = ['bo_rf', 'li_rf', 'injbo', 'as_pu', 'bo_ps']
 
+    PU_VOLTAGE_UP_TIME = 30  # [s]
+
 
 _ct = Const
 
@@ -212,6 +214,12 @@ def get_injctrl_propty_database():
         'TopUpHeadStartTime-RB': {
             'type': 'float', 'value': 0, 'unit': 's', 'prec': 2,
             'lolim': 0, 'hilim': 2*60},
+        'TopUpPUStandbyEnbl-Sel': {
+            'type': 'enum', 'value': _ct.DsblEnbl.Dsbl,
+            'enums': _et.DSBL_ENBL},
+        'TopUpPUStandbyEnbl-Sts': {
+            'type': 'enum', 'value': _ct.DsblEnbl.Dsbl,
+            'enums': _et.DSBL_ENBL},
         'TopUpNextInj-Mon': {
             'type': 'float', 'value': 0.0, 'unit': 's'},
         'TopUpNrPulses-SP': {

--- a/siriuspy/siriuspy/injctrl/main.py
+++ b/siriuspy/siriuspy/injctrl/main.py
@@ -318,7 +318,9 @@ class App(_Callback):
 
         if value == _Const.InjMode.TopUp and \
                 self._topupstate_sts == _Const.TopUpSts.Off:
-            self._update_log('Waiting to start top-up.')
+            self._update_log('Configuring EVG RepeatBucketList...')
+            self._evg_dev['RepeatBucketList-SP'] = 1
+            self._update_log('...done. Waiting to start top-up.')
         else:
             if self._topup_thread and self._topup_thread.is_alive():
                 self._stop_topup_thread()
@@ -843,6 +845,9 @@ class App(_Callback):
 
     def _callback_watch_repeatbucketlist(self, value, **kws):
         if self._mode == _Const.InjMode.TopUp:
+            if value != 1:
+                self._update_log('WARN:RepeatBucketList is diff. from 1.')
+                self._update_log('WARN:Aborting top-up...')
             return
         if self._autostop == _Const.OffOn.On and value != 0:
             self._autostop = _Const.OffOn.Off

--- a/siriuspy/siriuspy/injctrl/main.py
+++ b/siriuspy/siriuspy/injctrl/main.py
@@ -1037,7 +1037,7 @@ class App(_Callback):
                 break
 
             self._update_log('Top-up period elapsed. Preparing...')
-            if self._currinfo_dev.current < 102.0:
+            if self._currinfo_dev.current < self._target_current:
                 self._update_topupsts(_Const.TopUpSts.TurningOn)
                 self._update_log('Starting injection...')
                 if not self._start_injection():

--- a/siriuspy/siriuspy/injctrl/main.py
+++ b/siriuspy/siriuspy/injctrl/main.py
@@ -789,6 +789,14 @@ class App(_Callback):
                 if self._injsys_dev.is_on:
                     self._update_log('Inj.System is on.')
                     break
+                else:
+                    # handle a timing configuration that do not use InjBO evt
+                    states = self._injsys_dev.get_dev_state(
+                        ['bo_rf', 'as_pu', 'bo_ps', 'li_rf'])
+                    if all(states):
+                        self._update_log('Ignoring InjBO event off state...')
+                        self._update_log('...Inj.System is on.')
+                        break
             else:
                 self._update_log('ERR:Timed out waiting for Inj.Sys.')
                 return False

--- a/siriuspy/siriuspy/injctrl/main.py
+++ b/siriuspy/siriuspy/injctrl/main.py
@@ -502,10 +502,19 @@ class App(_Callback):
         """Set bucketlist_step."""
         if not -_Const.MAX_BKT+1 <= step <= _Const.MAX_BKT-1:
             return False
-        start = self._bucketlist_start
-        stop = self._bucketlist_stop
-        if not self._cmd_bucketlist_fill(stop, start, step):
-            return False
+        if self._mode == _Const.InjMode.TopUp:
+            bucket = _np.arange(self._topupnrpulses) + 1
+            bucket *= step
+            bucket += self._evg_dev.bucketlist[0] - 1
+            bucket %= 864
+            bucket += 1
+            if not self._set_bucket_list(bucket):
+                return False
+        else:
+            start = self._bucketlist_start
+            stop = self._bucketlist_stop
+            if not self._cmd_bucketlist_fill(stop, start, step):
+                return False
         self._bucketlist_step = step
         self.run_callbacks('BucketListStep-RB', step)
         return True
@@ -579,6 +588,13 @@ class App(_Callback):
             return False
 
         self._topupnrpulses = value
+        if self._mode == _Const.InjMode.TopUp:
+            bucket = _np.arange(self._topupnrpulses) + 1
+            bucket *= self._bucketlist_step
+            bucket += self._evg_dev.bucketlist[0] - 1
+            bucket %= 864
+            bucket += 1
+            self._set_bucket_list(bucket)
         self._update_log('Changed top-up nr.pulses to '+str(value)+'.')
         self.run_callbacks('TopUpNrPulses-RB', self._topupnrpulses)
         return True


### PR DESCRIPTION
Hi guys, this PR updates InjCtrl IOC:
- set RepeatBucketList to 1 when in top-up mode
- handle timing configurations that do not use InjBO evt
- when in top-up mode, update bucket list when top-up settings change
- use target current instead of hardcoded limit value in top-up injection checks
- add option to set PU voltage to standby values between top-up injections
- remove TRIG_Norm and Pulse_Current from modulators states that must be always on
- clean up code.

And also LI modulators Diag IOC:
- add bits corresponding to the CHARGE and TRIGOUT states
- only check some states when CHARGE and TRIGOUT are on