### PR TITLE
Update InjCtrl IOC

### DIFF
--- a/siriuspy/siriuspy/devices/egun.py
+++ b/siriuspy/siriuspy/devices/egun.py
@@ -560,7 +560,7 @@ class EGun(_Devices, _Callback):
         self._abort_chg_type.clear()
         self._update_status('Switching EGun mode to SingleBunch...')
 
-        if not self.connected:
+        if not self.wait_for_connection(1):
             self._update_status('ERR:EGun device not connected. Aborted.')
             return False
 
@@ -594,7 +594,7 @@ class EGun(_Devices, _Callback):
         self._abort_chg_type.clear()
         self._update_status('Switching EGun mode to MultiBunch...')
 
-        if not self.connected:
+        if not self.wait_for_connection(1):
             self._update_status('ERR:EGun device not connected. Aborted.')
             return False
 
@@ -624,7 +624,7 @@ class EGun(_Devices, _Callback):
     @property
     def is_single_bunch(self):
         """Is configured to single bunch mode."""
-        if not self.connected:
+        if not self.wait_for_connection(1):
             return False
         sts = not self.pulse.multi_bunch_switch
         sts &= not self.pulse.multi_bunch_mode
@@ -638,7 +638,7 @@ class EGun(_Devices, _Callback):
     @property
     def is_multi_bunch(self):
         """Is configured to multi bunch mode."""
-        if not self.connected:
+        if not self.wait_for_connection(1):
             return False
         sts = not self.pulse.single_bunch_switch
         sts &= not self.pulse.single_bunch_mode
@@ -671,7 +671,7 @@ class EGun(_Devices, _Callback):
     @property
     def is_hv_on(self):
         """Indicate whether high voltage is on and in operational value."""
-        if not self.hvps.connected:
+        if not self.hvps.wait_for_connection(1):
             return False
         is_on = self.hvps.is_on()
         is_op = abs(self.hvps.voltage_mon - self._hv_opval) < self._hv_tol
@@ -787,7 +787,7 @@ class EGun(_Devices, _Callback):
     @property
     def is_fila_on(self):
         """Indicate whether filament is on and in operational current."""
-        if not self.fila.connected:
+        if not self.fila.wait_for_connection(1):
             return False
         is_on = self.fila.is_on()
         is_op_sp = abs(self.fila['currentoutsoft']-self._filacurr_opval) < 1e-4
@@ -926,7 +926,7 @@ class EGun(_Devices, _Callback):
 
     def _check_status_ok(self):
         """Check if interlock signals are ok."""
-        if not self.connected:
+        if not self.wait_for_connection(1):
             return False
         isok = [self.mps_ccg[ppty] == 0 for ppty in self.mps_ccg.properties]
         allok = all(isok)

--- a/siriuspy/siriuspy/injctrl/main.py
+++ b/siriuspy/siriuspy/injctrl/main.py
@@ -1069,8 +1069,8 @@ class App(_Callback):
                 self._update_log('ERR:...aborted top-up loop.')
                 return
 
-            # if remaining time is lower than wait time, do not set PU voltage
-            if self._topupnext - _time.time() <= _Const.PU_VOLTAGE_UP_TIME:
+            # if remaining time is short, do not handle PU voltage
+            if self._topupnext - _time.time() <= _Const.PU_VOLTAGE_UP_TIME*2:
                 self._topup_pu_prepared = True
             else:
                 # else, set PU voltage to 50%

--- a/siriuspy/siriuspy/injctrl/main.py
+++ b/siriuspy/siriuspy/injctrl/main.py
@@ -35,10 +35,6 @@ class App(_Callback):
         self._mode = _Const.InjMode.Decay
         self._type = _Const.InjType.MultiBunch
         self._type_mon = _Const.InjTypeMon.Undefined
-        self._sglbunbiasvolt = EGun.BIAS_SINGLE_BUNCH
-        self._multbunbiasvolt = EGun.BIAS_MULTI_BUNCH
-        self._filaopcurr = EGun.FILACURR_OPVALUE
-        self._hvopvolt = EGun.HV_OPVALUE
         self._pumode = _Const.PUMode.Accumulation
         self._pumode_mon = _Const.PUModeMon.Undefined
         self._p2w = {
@@ -209,6 +205,30 @@ class App(_Callback):
         self.thread_check_injstatus = _epics.ca.CAThread(
             target=self._update_injstatus, daemon=True)
         self.thread_check_injstatus.start()
+
+        # initialize default operation values with implemented values
+        self._egun_dev.wait_for_connection()
+        biasvolt = self._egun_dev.bias.voltage
+        if biasvolt is None:
+            self._sglbunbiasvolt = _Const.BIAS_SINGLE_BUNCH
+            self._multbunbiasvolt = _Const.BIAS_MULTI_BUNCH
+        else:
+            self._sglbunbiasvolt = biasvolt
+            self._multbunbiasvolt = biasvolt
+            self._egun_dev.single_bunch_bias_voltage = biasvolt
+            self._egun_dev.multi_bunch_bias_voltage = biasvolt
+        filacurr = self._egun_dev.fila.current
+        if filacurr is None:
+            self._filaopcurr = _Const.FILACURR_OPVALUE
+        else:
+            self._filaopcurr = filacurr
+            self._egun_dev.fila_current_opvalue = filacurr
+        hvvolt = self._egun_dev.hvps.voltage
+        if hvvolt is None:
+            self._hvopvolt = _Const.HV_OPVALUE
+        else:
+            self._hvopvolt = hvvolt
+            self._egun_dev.high_voltage_opvalue = hvvolt
 
     def init_database(self):
         """Set initial PV values."""

--- a/siriuspy/siriuspy/injctrl/main.py
+++ b/siriuspy/siriuspy/injctrl/main.py
@@ -14,7 +14,7 @@ from ..search import PSSearch as _PSSearch, HLTimeSearch as _HLTimeSearch
 from ..diagsys.lidiag.csdev import Const as _LIDiagConst, ETypes as _LIDiagEnum
 from ..diagsys.psdiag.csdev import ETypes as _PSDiagEnum
 from ..diagsys.rfdiag.csdev import Const as _RFDiagConst
-from ..devices import InjSysStandbyHandler, EVG, EGun, CurrInfoSI, MachShift, \
+from ..devices import InjSysStandbyHandler, EVG, EGun, CurrInfoSI, \
     PowerSupplyPU, RFKillBeam, InjSysPUModeHandler
 
 from .csdev import Const as _Const, ETypes as _ETypes, \

--- a/siriuspy/siriuspy/injctrl/main.py
+++ b/siriuspy/siriuspy/injctrl/main.py
@@ -160,8 +160,6 @@ class App(_Callback):
 
         self._injsys_dev = InjSysStandbyHandler()
 
-        self._macshift_dev = MachShift()
-
         self._currinfo_dev = CurrInfoSI()
 
         self._pu_names = _PSSearch.get_psnames(

--- a/siriuspy/siriuspy/injctrl/main.py
+++ b/siriuspy/siriuspy/injctrl/main.py
@@ -165,7 +165,7 @@ class App(_Callback):
             {'dis': 'PU', 'dev': '.*(InjKckr|EjeKckr|InjNLKckr|Sept)'})
         self._pu_devs = [PowerSupplyPU(pun) for pun in self._pu_names]
         self._pu_refvolt = list()
-        self._topup_puref_ignore  = False
+        self._topup_puref_ignore = False
         for dev in self._pu_devs:
             pvo = dev.pv_object('Voltage-SP')
             self._pu_refvolt.append(pvo.value)

--- a/siriuspy/siriuspy/injctrl/main.py
+++ b/siriuspy/siriuspy/injctrl/main.py
@@ -989,7 +989,7 @@ class App(_Callback):
                     return False
                 if not self._evg_dev.injection_state:
                     break
-            _time.sleep(0.02)
+                _time.sleep(0.02)
         else:
             # if in decay mode, wait for target current to be reached
             while True:


### PR DESCRIPTION
Hi guys, this PR updates InjCtrl IOC:
- does not set PU voltage to standby on top-up start if remaining time is short (< 1min)
- removes unnecessary warnings in top-up mode (related to bucket list sync status and LI modulators standby status)
- uses pyepics recommendations for threading (trying to handle strange bug observed in last machine studies, on which top-up thread crashed silently)
- tries to handle disconnections gracefully
- initialize default Linac operation values (filament current, HV voltage and bias voltages) with implemented values
- fixes bugs and cleanup code

Also, this PR:
- in EGun device: replaces checking the connection with waiting for the connection, to avoid None values on initialization
- in FOFB: also uses pyepics recommendations for threading