### PR TITLE
Update SOFB IOC

### DIFF
--- a/siriuspy/siriuspy/clientconfigdb/_templates.py
+++ b/siriuspy/siriuspy/clientconfigdb/_templates.py
@@ -18,12 +18,12 @@ _INT_TYPES = {int}
 _FLOAT_TYPES = {float}
 
 
-for key, typ in _np.typeDict.items():
+for key, typ in _np.sctypeDict.items():
     if isinstance(key, str) and key.startswith('int'):
         _INT_TYPES.add(typ)
 
 
-for key, typ in _np.typeDict.items():
+for key, typ in _np.sctypeDict.items():
     if isinstance(key, str) and key.startswith('float'):
         _FLOAT_TYPES.add(typ)
 

--- a/siriuspy/siriuspy/sofb/main.py
+++ b/siriuspy/siriuspy/sofb/main.py
@@ -881,8 +881,6 @@ class SOFB(_BaseClass):
 
             if not self._check_valid_orbit(orb):
                 self._loop_state = self._csorb.LoopState.Open
-                if fofb.connected and fofb.loop_state:
-                    fofb.loop_state = 0
                 self.run_callbacks('LoopState-Sel', 0)
                 break
 


### PR DESCRIPTION
This PR changes SOFB IOC to do not open the FOFB loop when orbit problems are detected, as FOFB already has orbit distortion and packet loss detection functionalities.
Also, this PR replace numpy.typeDict by numpy.sctypeDict, as numpy alias typeDict has been formally deprecated (https://github.com/numpy/numpy/releases/tag/v1.21.0)