### PR TITLE
Add Topup BiasFB

### DIFF
--- a/siriuspy/siriuspy/callbacks.py
+++ b/siriuspy/siriuspy/callbacks.py
@@ -18,6 +18,16 @@ class Callback:
         else:
             self.add_callback(callback)
 
+    @property
+    def has_callbacks(self):
+        """Return a flag indicating whether object has a callback attached.
+
+        Returns:
+            bool: whether or not there is a registered callback.
+
+        """
+        return bool(self._callbacks)
+
     def add_callback(self, callback, index=None, **kw):
         """Add a callback to a PV.
 

--- a/siriuspy/siriuspy/currinfo/lifetime/main.py
+++ b/siriuspy/siriuspy/currinfo/lifetime/main.py
@@ -37,7 +37,6 @@ class SILifetimeApp(_Callback):
         self._last_ts_set = 'last'
         self._sampling_interval = 500.0
         self._min_intvl_btw_spl = 0.0
-        self._rstbuff_cmd_count = 0
         self._buffautorst_mode = _Const.BuffAutoRst.DCurrCheck
         self._buffautorst_dcurr = 0.01
         self._is_stored = 0
@@ -163,9 +162,7 @@ class SILifetimeApp(_Callback):
             self.run_callbacks('CurrOffset-RB', value)
             status = True
         elif reason == 'BuffRst-Cmd':
-            self._rstbuff_cmd_count += 1
             self._reset_buff()
-            self.run_callbacks('BuffRst-Cmd', self._rstbuff_cmd_count)
             status = True
         elif reason == 'BuffAutoRst-Sel':
             self._buffautorst_mode = value

--- a/siriuspy/siriuspy/currinfo/main.py
+++ b/siriuspy/siriuspy/currinfo/main.py
@@ -611,17 +611,12 @@ class SICurrInfoApp(_CurrInfoApp):
         timestamp_dq = _np.asarray(timestamp_dq)
         value_dq = _np.asarray(value_dq)
 
-        # check buffer not empty
-        if not timestamp_dq.size:
-            return
-
-        # check if there is valid current in Booster
-        if bo_curr < self.CURR_THRESHOLD:
-            return
-
-        # calculate efficiency
-        self._injcurr = value_dq.max() - value_dq.min()  # mA
-        self._injeff = 100*(self._injcurr/bo_curr) * self.HARMNUM_RATIO
+        self._injcurr = 0.0
+        self._injeff = 0.0
+        # check if buffer not empty and if there is valid current in Booster
+        if timestamp_dq.size and bo_curr >= self.CURR_THRESHOLD:
+            self._injcurr = value_dq.max() - value_dq.min()  # mA
+            self._injeff = 100*(self._injcurr/bo_curr) * self.HARMNUM_RATIO
 
         # calculate injected charge: 1e6 * mA / Hz = nC
         self._injcharge = 1e6*self._injcurr*self.HARMNUM/self._rffreq_pv.value

--- a/siriuspy/siriuspy/currinfo/main.py
+++ b/siriuspy/siriuspy/currinfo/main.py
@@ -615,7 +615,7 @@ class SICurrInfoApp(_CurrInfoApp):
         self._injeff = 0.0
         # check if buffer not empty and if there is valid current in Booster
         if timestamp_dq.size and bo_curr >= self.CURR_THRESHOLD:
-            self._injcurr = value_dq.max() - value_dq.min()  # mA
+            self._injcurr = value_dq.ptp()  # mA
             self._injeff = 100*(self._injcurr/bo_curr) * self.HARMNUM_RATIO
 
         # calculate injected charge: 1e6 * mA / Hz = nC

--- a/siriuspy/siriuspy/devices/injctrl.py
+++ b/siriuspy/siriuspy/devices/injctrl.py
@@ -1,5 +1,6 @@
 """Injection control IOC device."""
 
+import numpy as _np
 from .device import Device as _Device
 
 from ..clientarch import Time
@@ -16,6 +17,7 @@ class InjCtrl(_Device):
     PUMode = _Const.PUMode
     PUModeMon = _Const.PUModeMon
     TopUpSts = _Const.TopUpSts
+    BiasFBModelTypes = _Const.BiasFBModelTypes
 
     _properties = (
         'Mode-Sel', 'Mode-Sts',
@@ -40,6 +42,36 @@ class InjCtrl(_Device):
         'InjSysTurnOffOrder-SP', 'InjSysTurnOffOrder-RB',
         'RFKillBeam-Cmd', 'RFKillBeam-Mon',
         'DiagStatus-Mon', 'InjStatus-Mon',
+        #  ----- bias feedback -----
+        'BiasFBLoopState-Sel', 'BiasFBLoopState-Sts',
+        'BiasFBMinVoltage-SP', 'BiasFBMinVoltage-RB',
+        'BiasFBMaxVoltage-SP', 'BiasFBMaxVoltage-RB',
+        'BiasFBModelType-Sel', 'BiasFBModelType-Sts',
+        'BiasFBModelMaxNrPts-SP', 'BiasFBModelMaxNrPts-RB',
+        'BiasFBModelNrPts-Mon',
+        'BiasFBModelAutoFitParams-Sel', 'BiasFBModelAutoFitParams-Sts',
+        'BiasFBModelAutoFitEveryNrPts-SP', 'BiasFBModelAutoFitEveryNrPts-RB',
+        'BiasFBModelNrPtsAfterFit-Mon', 'BiasFBModelFitParamsNow-Cmd',
+        'BiasFBModelUpdateData-Sel', 'BiasFBModelUpdateData-Sts',
+        'BiasFBModelDataBias-SP', 'BiasFBModelDataBias-RB',
+        'BiasFBModelDataBias-Mon',
+        'BiasFBModelDataInjCurr-SP', 'BiasFBModelDataInjCurr-RB',
+        'BiasFBModelDataInjCurr-Mon',
+        'BiasFBLinModAngCoeff-SP', 'BiasFBLinModAngCoeff-RB',
+        'BiasFBLinModAngCoeff-Mon',
+        'BiasFBLinModOffCoeff-SP', 'BiasFBLinModOffCoeff-RB',
+        'BiasFBLinModOffCoeff-Mon',
+        'BiasFBLinModInferenceInjCurr-Mon', 'BiasFBLinModInferenceBias-Mon',
+        'BiasFBLinModPredBias-Mon', 'BiasFBLinModPredInjCurrAvg-Mon',
+        'BiasFBGPModNoiseStd-SP', 'BiasFBGPModNoiseStd-RB',
+        'BiasFBGPModNoiseStd-Mon',
+        'BiasFBGPModKernStd-SP', 'BiasFBGPModKernStd-RB',
+        'BiasFBGPModKernStd-Mon',
+        'BiasFBGPModKernLenScl-SP', 'BiasFBGPModKernLenScl-RB',
+        'BiasFBGPModKernLenScl-Mon',
+        'BiasFBGPModInferenceInjCurr-Mon', 'BiasFBGPModInferenceBias-Mon',
+        'BiasFBGPModPredBias-Mon', 'BiasFBGPModPredInjCurrAvg-Mon',
+        'BiasFBGPModPredInjCurrStd-Mon',
     )
 
     class DEVICES:
@@ -261,6 +293,238 @@ class InjCtrl(_Device):
     def topup_nextinj_time(self):
         """Next topup scheduled injection Time object."""
         return Time.fromtimestamp(self['TopUpNextInj-Mon'])
+
+    # ----- bias feedback properties -----
+
+    @property
+    def biasfb_loop_state(self):
+        """Bias FB loop state."""
+        return self['BiasFBLoopState-Sts']
+
+    @biasfb_loop_state.setter
+    def biasfb_loop_state(self, value):
+        self._enum_setter('BiasFBLoopState-Sel', value, self.OffOn)
+
+    @property
+    def biasfb_voltage_min(self):
+        """Bias FB minimum voltage [V]."""
+        return self['BiasFBMinVoltage-RB']
+
+    @biasfb_voltage_min.setter
+    def biasfb_voltage_min(self, value):
+        self['BiasFBMinVoltage-SP'] = value
+
+    @property
+    def biasfb_voltage_max(self):
+        """Bias FB maximum voltage [V]."""
+        return self['BiasFBMaxVoltage-RB']
+
+    @biasfb_voltage_max.setter
+    def biasfb_voltage_max(self, value):
+        self['BiasFBMaxVoltage-SP'] = value
+
+    @property
+    def biasfb_model_type(self):
+        """Bias FB model type."""
+        return self['BiasFBModelType-Sts']
+
+    @biasfb_model_type.setter
+    def biasfb_model_type(self, value):
+        self._enum_setter('BiasFBModelType-Sel', value, self.BiasFBModelTypes)
+
+    @property
+    def biasfb_model_maxnrpts(self):
+        """Bias FB model maximum number of points [#]."""
+        return self['BiasFBModelMaxNrPts-RB']
+
+    @biasfb_model_maxnrpts.setter
+    def biasfb_model_maxnrpts(self, value):
+        self['BiasFBModelMaxNrPts-SP'] = value
+
+    @property
+    def biasfb_model_nrpts(self):
+        """Bias FB model number of points [#]."""
+        return self['BiasFBModelNrPts-Mon']
+
+    @property
+    def biasfb_model_autofit_enbl(self):
+        """Bias FB auto fit enable status."""
+        return self['BiasFBModelAutoFitParams-Sts']
+
+    @biasfb_model_autofit_enbl.setter
+    def biasfb_model_autofit_enbl(self, value):
+        self._enum_setter('BiasFBModelAutoFitParams-Sel', value, self.OffOn)
+
+    @property
+    def biasfb_model_autofit_rate(self):
+        """Bias FB model auto fit rate [#]."""
+        return self['BiasFBModelAutoFitEveryNrPts-RB']
+
+    @biasfb_model_autofit_rate.setter
+    def biasfb_model_autofit_rate(self, value):
+        self['BiasFBModelAutoFitEveryNrPts-SP'] = value
+
+    @property
+    def biasfb_model_nrpts_after_fit(self):
+        """Bias FB model number of points after last fit [#]."""
+        return self['BiasFBModelNrPtsAfterFit-Mon']
+
+    def cmd_biasfb_model_fitnow(self):
+        """Fit Bias FB model."""
+        self['BiasFBModelFitParamsNow-Cmd'] = 1
+        return True
+
+    @property
+    def biasfb_model_updatedata(self):
+        """Bias FB auto fit enable status."""
+        return self['BiasFBModelUpdateData-Sts']
+
+    @biasfb_model_updatedata.setter
+    def biasfb_model_updatedata(self, value):
+        self._enum_setter('BiasFBModelUpdateData-Sel', value, self.OffOn)
+
+    @property
+    def biasfb_model_data_bias(self):
+        """Bias FB model data bias setpoint [V]."""
+        return self['BiasFBModelDataBias-RB']
+
+    @biasfb_model_data_bias.setter
+    def biasfb_model_data_bias(self, value):
+        self['BiasFBModelDataBias-SP'] = _np.array(value, dtype=float)
+
+    @property
+    def biasfb_model_data_bias_mon(self):
+        """Bias FB implemented model data bias [V]."""
+        return self['BiasFBModelDataBias-Mon']
+
+    @property
+    def biasfb_model_data_injcurr(self):
+        """Bias FB model data injected current setpoint [mA]."""
+        return self['BiasFBModelDataInjCurr-RB']
+
+    @biasfb_model_data_injcurr.setter
+    def biasfb_model_data_injcurr(self, value):
+        self['BiasFBModelDataInjCurr-SP'] = _np.array(value, dtype=float)
+
+    @property
+    def biasfb_model_data_injcurr_mon(self):
+        """Bias FB implemented model data injected current [mA]."""
+        return self['BiasFBModelDataInjCurr-Mon']
+
+    @property
+    def biasfb_linmodel_angcoeff(self):
+        """Bias FB linear model angular coefficient."""
+        return self['BiasFBLinModAngCoeff-RB']
+
+    @biasfb_linmodel_angcoeff.setter
+    def biasfb_linmodel_angcoeff(self, value):
+        self['BiasFBLinModAngCoeff-SP'] = value
+
+    @property
+    def biasfb_linmodel_angcoeff_mon(self):
+        """Bias FB implemented linear model angular coefficient."""
+        return self['BiasFBLinModAngCoeff-Mon']
+
+    @property
+    def biasfb_linmodel_offcoeff(self):
+        """Bias FB linear model offset coefficient."""
+        return self['BiasFBLinModOffCoeff-RB']
+
+    @biasfb_linmodel_offcoeff.setter
+    def biasfb_linmodel_offcoeff(self, value):
+        self['BiasFBLinModOffCoeff-SP'] = value
+
+    @property
+    def biasfb_linmodel_offcoeff_mon(self):
+        """Bias FB implemented linear model offset coefficient."""
+        return self['BiasFBLinModOffCoeff-Mon']
+
+    @property
+    def biasfb_linmodel_infer_injcurr(self):
+        """Injected current for bias FB linear model inference."""
+        return self['BiasFBLinModInferenceInjCurr-Mon']
+
+    @property
+    def biasfb_linmodel_infer_bias(self):
+        """Bias for bias FB linear model inference."""
+        return self['BiasFBLinModInferenceBias-Mon']
+
+    @property
+    def biasfb_linmodel_predct_injcurr(self):
+        """Injected current for bias FB linear model prediction."""
+        return self['BiasFBLinModPredInjCurrAvg-Mon']
+
+    @property
+    def biasfb_linmodel_predct_bias(self):
+        """Bias for bias FB linear model prediction."""
+        return self['BiasFBLinModPredBias-Mon']
+
+    @property
+    def biasfb_gpmodel_likehd_std(self):
+        """Bias FB GP model likelihood standard deviation."""
+        return self['BiasFBGPModNoiseStd-RB']
+
+    @biasfb_gpmodel_likehd_std.setter
+    def biasfb_gpmodel_likehd_std(self, value):
+        self['BiasFBGPModNoiseStd-SP'] = value
+
+    @property
+    def biasfb_gpmodel_likehd_std_mon(self):
+        """Bias FB implemented GP model likelihood standard deviation."""
+        return self['BiasFBGPModNoiseStd-Mon']
+
+    @property
+    def biasfb_gpmodel_kern_std(self):
+        """Bias FB GP model kernel standard deviation."""
+        return self['BiasFBGPModKernStd-RB']
+
+    @biasfb_gpmodel_kern_std.setter
+    def biasfb_gpmodel_kern_std(self, value):
+        self['BiasFBGPModKernStd-SP'] = value
+
+    @property
+    def biasfb_gpmodel_kern_std_mon(self):
+        """Bias FB implemented GP model kernel standard deviation."""
+        return self['BiasFBGPModKernStd-Mon']
+
+    @property
+    def biasfb_gpmodel_kern_leng(self):
+        """Bias FB GP model kernel length scale."""
+        return self['BiasFBGPModKernLenScl-RB']
+
+    @biasfb_gpmodel_kern_leng.setter
+    def biasfb_gpmodel_kern_leng(self, value):
+        self['BiasFBGPModKernLenScl-SP'] = value
+
+    @property
+    def biasfb_gpmodel_kern_leng_mon(self):
+        """Bias FB implemented GP model kernel length scale."""
+        return self['BiasFBGPModKernLenScl-Mon']
+
+    @property
+    def biasfb_gpmodel_infer_injcurr(self):
+        """Injected current for bias FB GP model inference."""
+        return self['BiasFBGPModInferenceInjCurr-Mon']
+
+    @property
+    def biasfb_gpmodel_infer_bias(self):
+        """Bias for bias FB GB model inference."""
+        return self['BiasFBGPModInferenceBias-Mon']
+
+    @property
+    def biasfb_gpmodel_predct_injcurr_avg(self):
+        """Injected current for bias FB GB model prediction."""
+        return self['BiasFBGPModPredInjCurrAvg-Mon']
+
+    @property
+    def biasfb_gpmodel_predct_injcurr_std(self):
+        """Injected current for bias FB GB model prediction."""
+        return self['BiasFBGPModPredInjCurrStd-Mon']
+
+    @property
+    def biasfb_gpmodel_predct_bias(self):
+        """Bias for bias FB GB model prediction."""
+        return self['BiasFBGPModPredBias-Mon']
 
     # ----- injection system properties -----
 

--- a/siriuspy/siriuspy/injctrl/bias_feedback.py
+++ b/siriuspy/siriuspy/injctrl/bias_feedback.py
@@ -401,7 +401,7 @@ class BiasFeedback():
         ys, _ = self._gpmodel_predict(x)
         ys[ys < 0] = 0
         idm = ys[:, 0].argmax()
-        idm = _np.max(1, idm)
+        idm += 1
         idx = _np.argmin(_np.abs(ys[:idm] - y[None, :]), axis=0)
         return x[idx, 0]
 

--- a/siriuspy/siriuspy/injctrl/bias_feedback.py
+++ b/siriuspy/siriuspy/injctrl/bias_feedback.py
@@ -364,6 +364,7 @@ class BiasFeedback():
         bias = _np.linspace(self.min_bias_voltage, self.max_bias_voltage, 100)
         injc_lin = _np_poly.polyval(bias, self.linmodel_coeffs_inverse)
         injca_gp, injcs_gp = self._gpmodel_predict(bias)
+        injcs_gp = _np.sqrt(injcs_gp)
         self.run_callbacks('LinModPredBias-Mon', bias)
         self.run_callbacks('LinModPredInjCurrAvg-Mon', injc_lin)
         self.run_callbacks('GPModPredBias-Mon', bias)

--- a/siriuspy/siriuspy/injctrl/bias_feedback.py
+++ b/siriuspy/siriuspy/injctrl/bias_feedback.py
@@ -25,9 +25,9 @@ class BiasFeedback():
         self.max_bias_voltage = db_['BiasFBMaxVoltage-SP']['value']  # [V]
 
         self.model_type = db_['BiasFBModelType-Sel']['value']
-        self.model_max_num_points = db_['BiasFBModelMaxNumPts-SP']['value']
+        self.model_max_num_points = db_['BiasFBModelMaxNrPts-SP']['value']
         self.model_auto_fit_rate = db_[
-            'BiasFBModelAutoFitEveryNumPts-SP']['value']
+            'BiasFBModelAutoFitEveryNrPts-SP']['value']
         self.model_auto_fit = db_['BiasFBModelAutoFitParams-Sel']['value']
         self.model_update_data = db_['BiasFBModelUpdateData-Sel']['value']
 
@@ -54,10 +54,10 @@ class BiasFeedback():
             'MinVoltage-SP': self.set_min_voltage,
             'MaxVoltage-SP': self.set_max_voltage,
             'ModelType-Sel': self.set_model_type,
-            'ModelMaxNumPts-SP': self.set_max_num_pts,
+            'ModelMaxNrPts-SP': self.set_max_num_pts,
             'ModelFitParamsNow-Cmd': self.cmd_fit_params,
             'ModelAutoFitParams-Sel': self.set_auto_fit,
-            'ModelAutoFitEveryNumPts-SP': self.set_auto_fit_rate,
+            'ModelAutoFitEveryNrPts-SP': self.set_auto_fit_rate,
             'ModelUpdateData-Sel': self.set_update_data,
             'ModelDataBias-SP': self.set_data_bias,
             'ModelDataInjCurr-SP': self.set_data_injcurr,
@@ -151,7 +151,7 @@ class BiasFeedback():
         """."""
         self.model_max_num_points = int(value)
         self._update_models()
-        self.run_callbacks('ModelMaxNumPts-RB', value)
+        self.run_callbacks('ModelMaxNrPts-RB', value)
         return True
 
     def cmd_fit_params(self, value):
@@ -168,7 +168,7 @@ class BiasFeedback():
     def set_auto_fit_rate(self, value):
         """."""
         self.model_auto_fit_rate = int(value)
-        self.run_callbacks('ModelAutoFitEveryNumPts-RB', value)
+        self.run_callbacks('ModelAutoFitEveryNrPts-RB', value)
         return True
 
     def set_update_data(self, value):
@@ -343,7 +343,7 @@ class BiasFeedback():
             self.gpmodel.optimize_restarts(num_restarts=2, verbose=False)
             self._npts_after_fit = 0
 
-        self.run_callbacks('ModelNumPtsAfterFit-Mon', self._npts_after_fit)
+        self.run_callbacks('ModelNrPtsAfterFit-Mon', self._npts_after_fit)
         self._update_predictions()
 
     def _update_predictions(self):
@@ -357,7 +357,7 @@ class BiasFeedback():
 
         self.run_callbacks('ModelDataBias-Mon', self.gpmodel.X.ravel())
         self.run_callbacks('ModelDataInjCurr-Mon', self.gpmodel.Y.ravel())
-        self.run_callbacks('ModelNumPts-Mon', self.gpmodel.Y.size)
+        self.run_callbacks('ModelNrPts-Mon', self.gpmodel.Y.size)
 
         injcurr = _np.linspace(0, 1, 100)
         bias_lin = self._get_bias_voltage_linear_model(injcurr)

--- a/siriuspy/siriuspy/injctrl/bias_feedback.py
+++ b/siriuspy/siriuspy/injctrl/bias_feedback.py
@@ -401,6 +401,7 @@ class BiasFeedback():
         ys, _ = self._gpmodel_predict(x)
         ys[ys < 0] = 0
         idm = ys[:, 0].argmax()
+        idm = _np.max(1, idm)
         idx = _np.argmin(_np.abs(ys[:idm] - y[None, :]), axis=0)
         return x[idx, 0]
 

--- a/siriuspy/siriuspy/injctrl/bias_feedback.py
+++ b/siriuspy/siriuspy/injctrl/bias_feedback.py
@@ -70,7 +70,7 @@ class BiasFeedback():
             }
 
     @property
-    def use_gaussproc_model(self):
+    def use_gpmodel(self):
         """."""
         return self.model_type == _Const.BiasFBModelTypes.GaussianProcess
 
@@ -99,7 +99,7 @@ class BiasFeedback():
     def get_bias_voltage(self, dcurr):
         """."""
         dcurr = max(0, dcurr)
-        if self.use_gaussproc_model:
+        if self.use_gpmodel:
             return self._get_bias_voltage_gpmodel(dcurr)
         return self._get_bias_voltage_linear_model(dcurr)
 
@@ -322,7 +322,7 @@ class BiasFeedback():
         do_opt |= force_optimize
 
         # Optimize Linear Model
-        if do_opt and not self.use_gaussproc_model:
+        if do_opt and not self.use_gpmodel:
             self.linmodel_angcoeff = _np_poly.polyfit(
                 y, x - self.linmodel_offcoeff, deg=[1, ])[1]
             self._npts_after_fit = 0
@@ -333,7 +333,7 @@ class BiasFeedback():
         self.gpmodel.set_XY(x, y)
 
         # Optimize Gaussian Process Model
-        if do_opt and self.use_gaussproc_model:
+        if do_opt and self.use_gpmodel:
             self.gpmodel.optimize_restarts(num_restarts=2, verbose=False)
             self._npts_after_fit = 0
 

--- a/siriuspy/siriuspy/injctrl/bias_feedback.py
+++ b/siriuspy/siriuspy/injctrl/bias_feedback.py
@@ -1,0 +1,235 @@
+"""."""
+import time as _time
+
+from epics.ca import CAThread as _Thread
+import numpy as np
+import GPy as gpy
+
+from mathphys.functions import get_namedtuple
+from siriuspy.devices import HLTiming, EGun, InjCtrl, CurrInfoAS
+
+np_poly = np.polynomial.polynomial
+
+
+class BiasFeedback():
+    """."""
+
+    _DEF_TIMEOUT = 60 * 60  # [s]
+    _MINIMUM_LIFETIME = 1800  # [s]
+    ModelTypes = get_namedtuple('ModelTypes', ['Linear', 'GaussianProcess'])
+
+    def __init__(self):
+        """."""
+        self._already_set = False
+
+        self.min_bias_voltage = -52  # [V]
+        self.max_bias_voltage = -40  # [V]
+        self.ahead_set_time = 10  # [s]
+        self.linmodel_angcoeff = 10  # [V/mA]
+        self.model_type = self.ModelTypes.GaussianProcess
+        self.model_max_num_points = 20
+        self.model_opt_each_pts = 10
+
+        self._num_points_after_opt = 0
+
+        self.gpmodel = self.initialize_gpmodel()
+        self._create_devices()
+
+    @property
+    def model_type_str(self):
+        """."""
+        return self.ModelTypes._fields[self.model_type]
+
+    @property
+    def use_gaussproc_model(self):
+        """."""
+        return self.model_type == self.ModelTypes.GaussianProcess
+
+    @property
+    def linmodel_coeffs(self):
+        """."""
+        ang = self.linmodel_angcoeff
+        off = self.min_bias_voltage
+        return (off, ang)
+
+    def initialize_gpmodel(self):
+        """."""
+        bias = np.linspace(
+            self.min_bias_voltage,
+            self.max_bias_voltage,
+            self.model_max_num_points)
+
+        off, ang = self.linmodel_coeffs
+        dcurr = np_poly.polyval(bias, (-off/ang, 1/ang))
+
+        y = dcurr[:, None]
+        x = bias[:, None]
+
+        kernel = gpy.kern.RBF(input_dim=1)
+        gpmodel = gpy.models.GPRegression(x, y, kernel)
+        return gpmodel
+
+    def get_delta_current_per_pulse(
+            self, per=1, nrpul=1, curr_avg=100, curr_now=99.5, ltime=17*3600):
+        """."""
+        ltime = max(self._MINIMUM_LIFETIME, ltime)
+        curr_tar = curr_avg / (1 - per*60/2/ltime)
+        dcurr = (curr_tar - curr_now) / nrpul
+        return dcurr
+
+    def get_bias_voltage(self, dcurr):
+        """."""
+        if self.use_gaussproc_model:
+            return self._get_bias_voltage_gpmodel(dcurr)
+        return self._get_bias_voltage_linear_model(dcurr)
+
+    # ############ Auxiliary Methods ############
+    def _run(self):
+        """."""
+        print('Starting measurement:')
+        if self._stopevt.is_set():
+            return
+        egun = self.devices['egun']
+        injctrl = self.devices['injctrl']
+        currinfo = self.devices['currinfo']
+
+        self.data['dcurr'] = []
+        self.data['bias'] = []
+
+        pvo = egun.bias.pv_object('voltoutsoft')
+        pvo.auto_monitor = True
+        pvo = egun.bias.pv_object('voltinsoft')
+        pvo.auto_monitor = True
+        pvo = currinfo.si.pv_object('InjCurr-Mon')
+        pvo.auto_monitor = True
+        pvo = currinfo.bo.pv_object('Current3GeV-Mon')
+        pvo.auto_monitor = True
+        cbv = pvo.add_callback(self._callback_to_thread)
+
+        self._already_set = False
+        while not self._stopevt.is_set():
+            if injctrl.topup_state == injctrl.TopUpSts.Off:
+                print('Topup is Off. Exiting...')
+                break
+            _time.sleep(2)
+            next_inj = injctrl.topup_nextinj_timestamp
+            dtim = next_inj - _time.time()
+            if self._already_set or dtim > self.ahead_set_time:
+                continue
+            dcurr = self.get_delta_current_per_pulse()
+            bias = self.get_bias_voltage(dcurr)
+            egun.bias.set_voltage(bias)
+            print(f'dcurr = {dcurr:.3f}, bias = {bias:.2f}')
+            self._already_set = True
+        pvo.remove_callback(cbv)
+        print('Finished!')
+
+    def _create_devices(self):
+        self.devices['egun'] = EGun()
+        self.devices['injctrl'] = InjCtrl()
+        self.devices['currinfo'] = CurrInfoAS()
+
+    def _callback_to_thread(self, **kwgs):
+        _Thread(target=self._update_models, kwargs=kwgs, daemon=True).start()
+
+    def _update_models(self, **kwgs):
+        simul = kwgs.get('simul', False)
+        if not simul:
+            _time.sleep(1)
+
+        bias = kwgs.get('bias')
+        if bias is None:
+            bias = self.devices['egun'].bias.voltage
+        dcurr = kwgs.get('dcurr')
+        if dcurr is None:
+            dcurr = self.devices['currinfo'].si.injcurr
+
+        self.data['dcurr'].append(dcurr)
+        self.data['bias'].append(bias)
+
+        x = np.array(self.data['bias'])
+        y = np.array(self.data['dcurr'])
+        x = x[-self.model_max_num_points:]
+        y = y[-self.model_max_num_points:]
+
+        # Do not overload data with repeated points:
+        xun, cnts = np.unique(x, return_counts=True)
+        if bias in xun:
+            idx = (xun == bias).nonzero()[0][0]
+            if cnts[idx] >= max(2, x.size // 5):
+                return
+        self._num_points_after_opt += 1
+
+        opt = self.model_opt_each_pts
+        do_opt = opt and not (self._num_points_after_opt % opt)
+
+        # Optimize Linear Model
+        if do_opt and not self.use_gaussproc_model:
+            self.linmodel_angcoeff = np_poly.polyfit(
+                y, x-self.min_bias_voltage, deg=[1,])[1]
+            self._num_points_after_opt = 0
+
+        # update Gaussian Process Model data
+        x = self.gpmodel.X[:, 0]
+        y = self.gpmodel.Y[:, 0]
+        x = np.r_[x[:-1], bias, self.min_bias_voltage]
+        y = np.r_[y[:-1], dcurr, 0]
+        x = x[-self.model_max_num_points:]
+        y = y[-self.model_max_num_points:]
+        x.shape = (x.size, 1)
+        y.shape = (y.size, 1)
+        self.gpmodel.set_XY(x, y)
+
+        # Optimize Gaussian Process Model
+        if do_opt and self.use_gaussproc_model:
+            self.gpmodel.optimize_restarts(num_restarts=2, verbose=False)
+            self._num_points_after_opt = 0
+
+        if not simul:
+            _time.sleep(3)
+        self._already_set = False
+
+    def _get_bias_voltage_gpmodel(self, dcurr):
+        bias = self._gpmodel_infer_newx(np.array(dcurr, ndmin=1))
+        bias = np.minimum(bias, self.max_bias_voltage)
+        bias = np.maximum(bias, self.min_bias_voltage)
+        return bias if bias.size > 1 else bias[0]
+
+    def _get_bias_voltage_linear_model(self, dcurr):
+        bias = np_poly.polyval(dcurr, self.linmodel_coeffs)
+        bias = np.minimum(bias, self.max_bias_voltage)
+        bias = np.maximum(bias, self.min_bias_voltage)
+        bias = np.array([bias]).ravel()
+        return bias if bias.size > 1 else bias[0]
+
+    def _gpmodel_infer_newx(self, y):
+        """Infer x given y for current GP model.
+
+        The GP model object has its own infer_newX method, but it is slow and
+        didn't give good results in my tests. So I decided to implement this
+        simpler version, which works well.
+
+        Args:
+            y (numpy.ndarray, (N,)): y's for which we want to infer x.
+
+        Returns:
+            x: infered x's.
+
+        """
+        x = np.linspace(self.min_bias_voltage, self.max_bias_voltage, 100)
+        ys, _ = self._gpmodel_predict(x)
+        idx = np.argmin(np.abs(ys - y[None, :]), axis=0)
+        return x[idx, 0]
+
+    def _gpmodel_predict(self, x):
+        """Get the GP model prediction of the injected current.
+
+        Args:
+            x (numpy.ndarray): bias voltage.
+
+        Returns:
+            numpy.ndarray: predicted injected current.
+
+        """
+        x.shape = (x.size, 1)
+        return self.gpmodel.predict(x)

--- a/siriuspy/siriuspy/injctrl/bias_feedback.py
+++ b/siriuspy/siriuspy/injctrl/bias_feedback.py
@@ -5,8 +5,6 @@ from epics.ca import CAThread as _Thread
 import numpy as _np
 import GPy as gpy
 
-from ..epics import PV as _PV
-
 from .csdev import Const as _Const, get_biasfb_database as _get_database
 
 _np_poly = _np.polynomial.polynomial

--- a/siriuspy/siriuspy/injctrl/bias_feedback.py
+++ b/siriuspy/siriuspy/injctrl/bias_feedback.py
@@ -357,9 +357,11 @@ class BiasFeedback():
             x: infered x's.
 
         """
-        x = _np.linspace(self.min_bias_voltage, self.max_bias_voltage, 100)
+        x = _np.linspace(self.min_bias_voltage, self.max_bias_voltage, 300)
         ys, _ = self._gpmodel_predict(x)
-        idx = _np.argmin(_np.abs(ys - y[None, :]), axis=0)
+        ys[ys < 0] = 0
+        idm = ys[:, 0].argmax()
+        idx = _np.argmin(_np.abs(ys[:idm] - y[None, :]), axis=0)
         return x[idx, 0]
 
     def _gpmodel_predict(self, x):

--- a/siriuspy/siriuspy/injctrl/bias_feedback.py
+++ b/siriuspy/siriuspy/injctrl/bias_feedback.py
@@ -110,7 +110,7 @@ class BiasFeedback():
         if self._injctrl.has_callbacks:
             self._injctrl.run_callbacks(name, *args, **kwd)
             return
-        self.database[name]['value'] = kwd['value']
+        self.database[name]['value'] = args[0]
 
     def update_log(self, msg):
         """."""

--- a/siriuspy/siriuspy/injctrl/bias_feedback.py
+++ b/siriuspy/siriuspy/injctrl/bias_feedback.py
@@ -95,8 +95,8 @@ class BiasFeedback():
             self.max_bias_voltage,
             self.model_max_num_points)
 
-        off, ang = self.linmodel_coeffs
-        self.injc_data = _np_poly.polyval(self.bias_data, (-off/ang, 1/ang))
+        self.injc_data = _np_poly.polyval(
+            self.bias_data, self.linmodel_coeffs_inverse)
 
         y = self.bias_data[:, None].copy()
         x = self.injc_data[:, None].copy()

--- a/siriuspy/siriuspy/injctrl/bias_feedback.py
+++ b/siriuspy/siriuspy/injctrl/bias_feedback.py
@@ -28,19 +28,20 @@ class BiasFeedback():
 
         self.model_type = db_['BiasFBModelType-Sel']['value']
         self.model_max_num_points = db_['BiasFBModelMaxNumPts-SP']['value']
-        self.model_auto_fit_rate = db_['ModelAutoFitEveryNumPts-SP']['value']
-        self.model_auto_fit = db_['ModelAutoFitParams-Sel']['value']
-        self.model_update_data = db_['ModelUpdateData-Sel']['value']
+        self.model_auto_fit_rate = db_[
+            'BiasFBModelAutoFitEveryNumPts-SP']['value']
+        self.model_auto_fit = db_['BiasFBModelAutoFitParams-Sel']['value']
+        self.model_update_data = db_['BiasFBModelUpdateData-Sel']['value']
 
-        self.linmodel_angcoeff = db_['LinModAngCoeff-SP']['value']  # [V/mA]
-        self.linmodel_offcoeff = db_['LinModOffCoeff-SP']['value']  # [V]
+        self.linmodel_angcoeff = db_['BiasFBLinModAngCoeff-SP']['value']  # [V/mA]
+        self.linmodel_offcoeff = db_['BiasFBLinModOffCoeff-SP']['value']  # [V]
 
         self._npts_after_fit = 0
 
         self.bias_data = _np.array(
-            db_['ModelDataBias-Mon']['value'], dtype=float)
+            db_['BiasFBModelDataBias-Mon']['value'], dtype=float)
         self.injc_data = _np.array(
-            db_['ModelDataInjCurr-Mon']['value'], dtype=float)
+            db_['BiasFBModelDataInjCurr-Mon']['value'], dtype=float)
         self.gpmodel = None
         self._initialize_models()
 
@@ -255,15 +256,15 @@ class BiasFeedback():
         y = self.injc_data[:, None].copy()
 
         kernel = gpy.kern.RBF(input_dim=1)
-        db_ = self.database['GPModKernVar-RB']
+        db_ = self.database['BiasFBGPModKernVar-RB']
         kernel.variance.constrain_bounded(db_['low'], db_['high'])
         kernel.variance = db_['value']
-        db_ = self.database['GPModKernLenScl-RB']
+        db_ = self.database['BiasFBGPModKernLenScl-RB']
         kernel.lengthscale.constrain_bounded(db_['low'], db_['high'])
         kernel.lengthscale = db_['value']
 
         gpmodel = gpy.models.GPRegression(x, y, kernel)
-        db_ = self.database['GPModLikehdVar-RB']
+        db_ = self.database['BiasFBGPModNoiseVar-RB']
         gpmodel.likelihood.variance.constrain_bounded(db_['low'], db_['high'])
         gpmodel.likelihood.variance = db_['value']
         self.gpmodel = gpmodel
@@ -365,9 +366,9 @@ class BiasFeedback():
         injca_gp, injcs_gp = self._gpmodel_predict(bias)
         self.run_callbacks('LinModPredBias-Mon', bias)
         self.run_callbacks('LinModPredInjCurrAvg-Mon', injc_lin)
-        self.run_callbacks('GpModPredBias-Mon', bias)
-        self.run_callbacks('GpModPredInjCurrAvg-Mon', injca_gp.ravel())
-        self.run_callbacks('GpModPredInjCurrStd-Mon', injcs_gp.ravel())
+        self.run_callbacks('GPModPredBias-Mon', bias)
+        self.run_callbacks('GPModPredInjCurrAvg-Mon', injca_gp.ravel())
+        self.run_callbacks('GPModPredInjCurrStd-Mon', injcs_gp.ravel())
 
     def _get_bias_voltage_gpmodel(self, dcurr):
         bias = self._gpmodel_infer_newx(_np.array(dcurr, ndmin=1))

--- a/siriuspy/siriuspy/injctrl/bias_feedback.py
+++ b/siriuspy/siriuspy/injctrl/bias_feedback.py
@@ -3,11 +3,10 @@ import logging as _log
 
 from epics.ca import CAThread as _Thread
 import numpy as _np
+from numpy.polynomial import polynomial as _np_poly
 import GPy as gpy
 
 from .csdev import Const as _Const, get_biasfb_database as _get_database
-
-_np_poly = _np.polynomial.polynomial
 
 
 class BiasFeedback():
@@ -31,8 +30,10 @@ class BiasFeedback():
         self.model_auto_fit = db_['BiasFBModelAutoFitParams-Sel']['value']
         self.model_update_data = db_['BiasFBModelUpdateData-Sel']['value']
 
-        self.linmodel_angcoeff = db_['BiasFBLinModAngCoeff-SP']['value']  # [V/mA]
-        self.linmodel_offcoeff = db_['BiasFBLinModOffCoeff-SP']['value']  # [V]
+        self.linmodel_angcoeff = db_[
+            'BiasFBLinModAngCoeff-SP']['value']  # [V/mA]
+        self.linmodel_offcoeff = db_[
+            'BiasFBLinModOffCoeff-SP']['value']  # [V]
 
         self._npts_after_fit = 0
 
@@ -184,7 +185,7 @@ class BiasFeedback():
         if self.bias_data.size > max_:
             msg = f'WARN: Bias data is too big (>{max_:d}). '
             msg += 'Trimming first points.'
-            _log.warn(msg)
+            _log.warning(msg)
             self.update_log(msg)
             self.bias_data = self.bias_data[-max_:]
         self._update_models()
@@ -198,7 +199,7 @@ class BiasFeedback():
         if self.injc_data.size > max_:
             msg = f'WARN: InjCurr data is too big (>{max_:d}). '
             msg += 'Trimming first points.'
-            _log.warn(msg)
+            _log.warning(msg)
             self.update_log(msg)
             self.injc_data = self.injc_data[-max_:]
         self._update_models()
@@ -288,7 +289,7 @@ class BiasFeedback():
             if cnts[idx] >= max(2, self.bias_data.size // 5):
                 msg = 'WARN: Too many data with this abscissa. '
                 msg += 'Discarding point.'
-                _log.warn(msg)
+                _log.warning(msg)
                 self.update_log(msg)
                 return
         self._npts_after_fit += 1
@@ -309,7 +310,7 @@ class BiasFeedback():
             msg = 'WARN: Arrays with incompatible sizes. '
             msg += 'Trimming first points of '
             msg += 'bias.' if x.size > y.size else 'injcurr.'
-            _log.warn(msg)
+            _log.warning(msg)
             self.update_log(msg)
             siz = min(x.size, y.size)
             x = x[-siz:]

--- a/siriuspy/siriuspy/injctrl/bias_feedback.py
+++ b/siriuspy/siriuspy/injctrl/bias_feedback.py
@@ -70,6 +70,12 @@ class BiasFeedback():
             'GPModKernLenScl-SP': self.set_gp_kern_leng,
             }
 
+    def init_database(self):
+        """Set initial PV values."""
+        for key, pvdbase in self.database.items():
+            pvname = key.split(_Const.BIASFB_PROPTY_PREFIX)[1]
+            self.run_callbacks(pvname, pvdbase['value'])
+
     @property
     def use_gpmodel(self):
         """."""

--- a/siriuspy/siriuspy/injctrl/bias_feedback.py
+++ b/siriuspy/siriuspy/injctrl/bias_feedback.py
@@ -98,8 +98,8 @@ class BiasFeedback():
         self.injc_data = _np_poly.polyval(
             self.bias_data, self.linmodel_coeffs_inverse)
 
-        y = self.bias_data[:, None].copy()
-        x = self.injc_data[:, None].copy()
+        x = self.bias_data[:, None].copy()
+        y = self.injc_data[:, None].copy()
 
         kernel = gpy.kern.RBF(input_dim=1)
         db_ = self.database['GPModKernVar-RB']

--- a/siriuspy/siriuspy/injctrl/csdev.py
+++ b/siriuspy/siriuspy/injctrl/csdev.py
@@ -326,11 +326,11 @@ def get_biasfb_database():
             'prec': 1, 'lolim': -120, 'low': -120, 'lolo': -120,
             'hilim': -30.0, 'high': -30.0, 'hihi': -30.0},
         'MaxVoltage-SP': {
-            'type': 'float', 'value': -52, 'unit': 'V',
+            'type': 'float', 'value': -40, 'unit': 'V',
             'prec': 1, 'lolim': -120, 'low': -120, 'lolo': -120,
             'hilim': -30.0, 'high': -30.0, 'hihi': -30.0},
         'MaxVoltage-RB': {
-            'type': 'float', 'value': -52, 'unit': 'V',
+            'type': 'float', 'value': -40, 'unit': 'V',
             'prec': 1, 'lolim': -120, 'low': -120, 'lolo': -120,
             'hilim': -30.0, 'high': -30.0, 'hihi': -30.0},
 
@@ -452,13 +452,13 @@ def get_biasfb_database():
             'lolim': 0.005**2, 'low': 0.005**2, 'lolo': 0.005**2,
             'hilim': 0.5**2, 'high': 0.5**2, 'hihi': 0.5**2},
         'GPModNoiseVar-RB': {
-            'type': 'float', 'value': 0.4**2, 'unit': 'mA^2', 'prec': 6,
-            'lolim': 0.05**2, 'low': 0.05**2, 'lolo': 0.05**2,
-            'hilim': 1**2, 'high': 1**2, 'hihi': 1**2},
+            'type': 'float', 'value': 0.05**2, 'unit': 'mA^2', 'prec': 6,
+            'lolim': 0.005**2, 'low': 0.005**2, 'lolo': 0.005**2,
+            'hilim': 0.5**2, 'high': 0.5**2, 'hihi': 0.5**2},
         'GPModNoiseVar-Mon': {
-            'type': 'float', 'value': 0.4**2, 'unit': 'mA^2', 'prec': 6,
-            'lolim': 0.05**2, 'low': 0.05**2, 'lolo': 0.05**2,
-            'hilim': 1**2, 'high': 1**2, 'hihi': 1**2},
+            'type': 'float', 'value': 0.05**2, 'unit': 'mA^2', 'prec': 6,
+            'lolim': 0.005**2, 'low': 0.005**2, 'lolo': 0.005**2,
+            'hilim': 0.5**2, 'high': 0.5**2, 'hihi': 0.5**2},
         'GPModKernVar-SP': {
             'type': 'float', 'value': 0.4**2, 'unit': 'mA^2', 'prec': 6,
             'lolim': 0.05**2, 'low': 0.05**2, 'lolo': 0.05**2,

--- a/siriuspy/siriuspy/injctrl/csdev.py
+++ b/siriuspy/siriuspy/injctrl/csdev.py
@@ -340,19 +340,19 @@ def get_biasfb_database():
         'ModelType-Sts': {
             'type': 'enum', 'value': _ct.BiasFBModelTypes.GaussianProcess,
             'enums': _et.BIASFB_MODEL_TYPES, 'unit': 'Lin_GP'},
-        'ModelMaxNumPts-SP': {
+        'ModelMaxNrPts-SP': {
             'type': 'int', 'value': 20, 'unit': '#',
             'lolim': 2, 'low': 2, 'lolo': 2,
             'hilim': _ct.BIASFB_MAX_DATA_SIZE,
             'high': _ct.BIASFB_MAX_DATA_SIZE,
             'hihi': _ct.BIASFB_MAX_DATA_SIZE},
-        'ModelMaxNumPts-RB': {
+        'ModelMaxNrPts-RB': {
             'type': 'int', 'value': 20, 'unit': '#',
             'lolim': 0, 'low': 0, 'lolo': 0,
             'hilim': _ct.BIASFB_MAX_DATA_SIZE,
             'high': _ct.BIASFB_MAX_DATA_SIZE,
             'hihi': _ct.BIASFB_MAX_DATA_SIZE},
-        'ModelNumPts-Mon': {
+        'ModelNrPts-Mon': {
             'type': 'int', 'value': 20, 'unit': '#',
             'lolim': 2, 'low': 2, 'lolo': 2,
             'hilim': _ct.BIASFB_MAX_DATA_SIZE,
@@ -365,19 +365,19 @@ def get_biasfb_database():
         'ModelAutoFitParams-Sts': {
             'type': 'enum', 'value': _ct.OffOn.Off, 'enums': _et.OFF_ON,
             'unit': 'Off_On'},
-        'ModelAutoFitEveryNumPts-SP': {
+        'ModelAutoFitEveryNrPts-SP': {
             'type': 'int', 'value': 10, 'unit': '#',
             'lolim': 1, 'low': 1, 'lolo': 1,
             'hilim': _ct.BIASFB_MAX_DATA_SIZE,
             'high': _ct.BIASFB_MAX_DATA_SIZE,
             'hihi': _ct.BIASFB_MAX_DATA_SIZE},
-        'ModelAutoFitEveryNumPts-RB': {
+        'ModelAutoFitEveryNrPts-RB': {
             'type': 'int', 'value': 10, 'unit': '#',
             'lolim': 1, 'low': 1, 'lolo': 1,
             'hilim': _ct.BIASFB_MAX_DATA_SIZE,
             'high': _ct.BIASFB_MAX_DATA_SIZE,
             'hihi': _ct.BIASFB_MAX_DATA_SIZE},
-        'ModelNumPtsAfterFit-Mon': {
+        'ModelNrPtsAfterFit-Mon': {
             'type': 'int', 'value': 10, 'unit': '#',
             'lolim': 1, 'low': 1, 'lolo': 1,
             'hilim': _ct.BIASFB_MAX_DATA_SIZE,

--- a/siriuspy/siriuspy/injctrl/csdev.py
+++ b/siriuspy/siriuspy/injctrl/csdev.py
@@ -77,6 +77,7 @@ class Const(_csdev.Const):
     BIASFB_AHEADSETIME = 10  # [s]
     BIASFB_MINIMUM_LIFETIME = 1800  # [s]
     BIASFB_PROPTY_PREFIX = 'BiasFB'
+    BIASFB_MAX_DATA_SIZE = 1000
 
 
 _ct = Const
@@ -331,15 +332,21 @@ def get_biasfb_database():
         'ModelMaxNumPts-SP': {
             'type': 'int', 'value': 20, 'unit': '#',
             'lolim': 2, 'low': 2, 'lolo': 2,
-            'hilim': 1000, 'high': 1000, 'hihi': 1000},
+            'hilim': _ct.BIASFB_MAX_DATA_SIZE,
+            'high': _ct.BIASFB_MAX_DATA_SIZE,
+            'hihi': _ct.BIASFB_MAX_DATA_SIZE},
         'ModelMaxNumPts-RB': {
             'type': 'int', 'value': 20, 'unit': '#',
             'lolim': 0, 'low': 0, 'lolo': 0,
-            'hilim': 1000, 'high': 1000, 'hihi': 1000},
+            'hilim': _ct.BIASFB_MAX_DATA_SIZE,
+            'high': _ct.BIASFB_MAX_DATA_SIZE,
+            'hihi': _ct.BIASFB_MAX_DATA_SIZE},
         'ModelNumPts-Mon': {
             'type': 'int', 'value': 20, 'unit': '#',
             'lolim': 2, 'low': 2, 'lolo': 2,
-            'hilim': 1000, 'high': 1000, 'hihi': 1000},
+            'hilim': _ct.BIASFB_MAX_DATA_SIZE,
+            'high': _ct.BIASFB_MAX_DATA_SIZE,
+            'hihi': _ct.BIASFB_MAX_DATA_SIZE},
         'ModelFitParamsNow-Cmd': {'type': 'int', 'value': 0},
         'ModelAutoFitParams-Sel': {
             'type': 'enum', 'value': _ct.OffOn.Off, 'enums': _et.OFF_ON},
@@ -348,31 +355,43 @@ def get_biasfb_database():
         'ModelAutoFitEveryNumPts-SP': {
             'type': 'int', 'value': 10, 'unit': '#',
             'lolim': 1, 'low': 1, 'lolo': 1,
-            'hilim': 1000, 'high': 1000, 'hihi': 1000},
+            'hilim': _ct.BIASFB_MAX_DATA_SIZE,
+            'high': _ct.BIASFB_MAX_DATA_SIZE,
+            'hihi': _ct.BIASFB_MAX_DATA_SIZE},
         'ModelAutoFitEveryNumPts-RB': {
             'type': 'int', 'value': 10, 'unit': '#',
             'lolim': 1, 'low': 1, 'lolo': 1,
-            'hilim': 1000, 'high': 1000, 'hihi': 1000},
+            'hilim': _ct.BIASFB_MAX_DATA_SIZE,
+            'high': _ct.BIASFB_MAX_DATA_SIZE,
+            'hihi': _ct.BIASFB_MAX_DATA_SIZE},
         'ModelNumPtsAfterFit-Mon': {
             'type': 'int', 'value': 10, 'unit': '#',
             'lolim': 1, 'low': 1, 'lolo': 1,
-            'hilim': 1000, 'high': 1000, 'hihi': 1000},
+            'hilim': _ct.BIASFB_MAX_DATA_SIZE,
+            'high': _ct.BIASFB_MAX_DATA_SIZE,
+            'hihi': _ct.BIASFB_MAX_DATA_SIZE},
         'ModelUpdateData-Sel': {
             'type': 'enum', 'value': _ct.OffOn.Off, 'enums': _et.OFF_ON},
         'ModelUpdateData-Sts': {
             'type': 'enum', 'value': _ct.OffOn.Off, 'enums': _et.OFF_ON},
         'ModelDataBias-SP': {
-            'type': 'float', 'count': 1000, 'value': [0]*1000},
+            'type': 'float', 'count': _ct.BIASFB_MAX_DATA_SIZE,
+            'value': [0]*_ct.BIASFB_MAX_DATA_SIZE},
         'ModelDataBias-RB': {
-            'type': 'float', 'count': 1000, 'value': [0]*1000},
+            'type': 'float', 'count': _ct.BIASFB_MAX_DATA_SIZE,
+            'value': [0]*_ct.BIASFB_MAX_DATA_SIZE},
         'ModelDataBias-Mon': {
-            'type': 'float', 'count': 1000, 'value': [0]*1000},
+            'type': 'float', 'count': _ct.BIASFB_MAX_DATA_SIZE,
+            'value': [0]*_ct.BIASFB_MAX_DATA_SIZE},
         'ModelDataInjCurr-SP': {
-            'type': 'float', 'count': 1000, 'value': [0]*1000},
+            'type': 'float', 'count': _ct.BIASFB_MAX_DATA_SIZE,
+            'value': [0]*_ct.BIASFB_MAX_DATA_SIZE},
         'ModelDataInjCurr-RB': {
-            'type': 'float', 'count': 1000, 'value': [0]*1000},
+            'type': 'float', 'count': _ct.BIASFB_MAX_DATA_SIZE,
+            'value': [0]*_ct.BIASFB_MAX_DATA_SIZE},
         'ModelDataInjCurr-Mon': {
-            'type': 'float', 'count': 1000, 'value': [0]*1000},
+            'type': 'float', 'count': _ct.BIASFB_MAX_DATA_SIZE,
+            'value': [0]*_ct.BIASFB_MAX_DATA_SIZE},
 
         'LinModAngCoeff-SP': {
             'type': 'float', 'value': 10, 'unit': 'V/mA',

--- a/siriuspy/siriuspy/injctrl/csdev.py
+++ b/siriuspy/siriuspy/injctrl/csdev.py
@@ -118,22 +118,22 @@ def get_injctrl_propty_database():
 
         'Mode-Sel': {
             'type': 'enum', 'value': _ct.InjMode.Decay,
-            'enums': _et.INJMODE},
+            'enums': _et.INJMODE, 'unit': 'Decay_Topup'},
         'Mode-Sts': {
             'type': 'enum', 'value': _ct.InjMode.Decay,
-            'enums': _et.INJMODE},
+            'enums': _et.INJMODE, 'unit': 'Decay_Topup'},
         'Type-Sel': {
             'type': 'enum', 'value': _ct.InjType.MultiBunch,
-            'enums': _et.INJTYPE},
+            'enums': _et.INJTYPE, 'unit': 'SB_MB'},
         'Type-Sts': {
             'type': 'enum', 'value': _ct.InjType.MultiBunch,
-            'enums': _et.INJTYPE},
+            'enums': _et.INJTYPE, 'unit': 'SB_MB'},
         'Type-Mon': {
             'type': 'enum', 'value': _ct.InjTypeMon.Undefined,
-            'enums': _et.INJTYPE_MON},
+            'enums': _et.INJTYPE_MON, 'unit': 'SB_MB_Und'},
         'TypeCmdSts-Mon': {
             'type': 'enum', 'value': _ct.IdleRunning.Idle,
-            'enums': _et.IDLERUNNING},
+            'enums': _et.IDLERUNNING, 'unit': 'Idle_Run'},
         'SglBunBiasVolt-SP': {
             'type': 'float', 'value': egsbbias, 'prec': 1,
             'unit': 'V', 'lolim': -150.0, 'hilim': 0.0},
@@ -148,7 +148,7 @@ def get_injctrl_propty_database():
             'unit': 'V', 'lolim': -150.0, 'hilim': 0.0},
         'BiasVoltCmdSts-Mon': {
             'type': 'enum', 'value': _ct.IdleRunning.Idle,
-            'enums': _et.IDLERUNNING},
+            'enums': _et.IDLERUNNING, 'unit': 'Idle_Run'},
         'FilaOpCurr-SP': {
             'type': 'float', 'value': egfilacurr, 'prec': 3,
             'unit': 'A', 'lolim': 0.0, 'hilim': 1.5},
@@ -157,7 +157,7 @@ def get_injctrl_propty_database():
             'unit': 'A', 'lolim': 0.0, 'hilim': 1.5},
         'FilaOpCurrCmdSts-Mon': {
             'type': 'enum', 'value': _ct.IdleRunning.Idle,
-            'enums': _et.IDLERUNNING},
+            'enums': _et.IDLERUNNING, 'unit': 'Idle_Run'},
         'HVOpVolt-SP': {
             'type': 'float', 'value': eghvolt, 'prec': 3,
             'unit': 'kV', 'lolim': 0.0, 'hilim': 95.0},
@@ -166,19 +166,19 @@ def get_injctrl_propty_database():
             'unit': 'kV', 'lolim': 0.0, 'hilim': 95.0},
         'HVOpVoltCmdSts-Mon': {
             'type': 'enum', 'value': _ct.IdleRunning.Idle,
-            'enums': _et.IDLERUNNING},
+            'enums': _et.IDLERUNNING, 'unit': 'Idle_Run'},
         'PUMode-Sel': {
             'type': 'enum', 'value': _ct.PUMode.Accumulation,
-            'enums': _et.PUMODE},
+            'enums': _et.PUMODE, 'unit': 'Acq_Opt_OnA'},
         'PUMode-Sts': {
             'type': 'enum', 'value': _ct.PUMode.Accumulation,
-            'enums': _et.PUMODE},
+            'enums': _et.PUMODE, 'unit': 'Acq_Opt_OnA'},
         'PUMode-Mon': {
             'type': 'enum', 'value': _ct.PUModeMon.Undefined,
-            'enums': _et.PUMODE_MON},
+            'enums': _et.PUMODE_MON, 'unit': 'Acq_Opt_OnA_Und'},
         'PUModeCmdSts-Mon': {
             'type': 'enum', 'value': _ct.IdleRunning.Idle,
-            'enums': _et.IDLERUNNING},
+            'enums': _et.IDLERUNNING, 'unit': 'Idle_Run'},
         'TargetCurrent-SP': {
             'type': 'float', 'value': 100.0, 'unit': 'mA',
             'prec': 2, 'lolim': 0.0, 'low': 0.0, 'lolo': 0.0,
@@ -207,9 +207,10 @@ def get_injctrl_propty_database():
             'lolim': -_ct.MAX_BKT+1, 'hilim': _ct.MAX_BKT-1},
 
         'TopUpState-Sel': {
-            'type': 'enum', 'value': _ct.OffOn.Off, 'enums': _et.OFF_ON},
+            'type': 'enum', 'value': _ct.OffOn.Off, 'enums': _et.OFF_ON, 'unit': 'Off_On'},
         'TopUpState-Sts': {
-            'type': 'enum', 'value': _ct.TopUpSts.Off, 'enums': _et.TOPUPSTS},
+            'type': 'enum', 'value': _ct.TopUpSts.Off, 'enums': _et.TOPUPSTS,
+            'unit': 'Off_Wai_TOn_Inj_TOff_Skip'},
         'TopUpPeriod-SP': {
             'type': 'int', 'value': 5, 'unit': 'min',
             'lolim': 1, 'hilim': 6*60},
@@ -224,10 +225,10 @@ def get_injctrl_propty_database():
             'lolim': 0, 'hilim': 2*60},
         'TopUpPUStandbyEnbl-Sel': {
             'type': 'enum', 'value': _ct.DsblEnbl.Dsbl,
-            'enums': _et.DSBL_ENBL},
+            'enums': _et.DSBL_ENBL, 'unit': 'Dsbl_Enbl'},
         'TopUpPUStandbyEnbl-Sts': {
             'type': 'enum', 'value': _ct.DsblEnbl.Dsbl,
-            'enums': _et.DSBL_ENBL},
+            'enums': _et.DSBL_ENBL, 'unit': 'Dsbl_Enbl'},
         'TopUpNextInj-Mon': {
             'type': 'float', 'value': 0.0, 'unit': 's'},
         'TopUpNrPulses-SP': {
@@ -249,48 +250,56 @@ def get_injctrl_propty_database():
         'InjSysTurnOffOrder-SP': {'type': 'string', 'value': injsys_offorder},
         'InjSysTurnOffOrder-RB': {'type': 'string', 'value': injsys_offorder},
 
-        'RFKillBeam-Cmd': {'type': 'int', 'value': 0},
+        'RFKillBeam-Cmd': {'type': 'int', 'value': 0, 'unit': '#'},
         'RFKillBeam-Mon': {
             'type': 'enum', 'value': _ct.RFKillBeamMon.Idle,
-            'enums': _et.RFKILLBEAMMON},
+            'enums': _et.RFKILLBEAMMON, 'unit': 'Idle_Kill'},
 
         'DiagStatusLI-Mon': {
-            'type': 'int', 'value': 2**len(_ct.LI_STATUS_LABELS)-1},
+            'type': 'int', 'value': 2**len(_ct.LI_STATUS_LABELS)-1,
+            'unit': '2^_Eg_PS_PU_RF_TI'},
         'DiagStatusLILabels-Cte': {
             'type': 'char', 'count': 1000,
             'value': '\n'.join(_ct.LI_STATUS_LABELS)},
         'DiagStatusTB-Mon': {
-            'type': 'int', 'value': 2**len(_ct.TL_STATUS_LABELS)-1},
+            'type': 'int', 'value': 2**len(_ct.TL_STATUS_LABELS)-1,
+            'unit': '2^_PS_PU_TI'},
         'DiagStatusTBLabels-Cte': {
             'type': 'char', 'count': 1000,
             'value': '\n'.join(_ct.TL_STATUS_LABELS)},
         'DiagStatusBO-Mon': {
-            'type': 'int', 'value': 2**len(_ct.SR_STATUS_LABELS)-1},
+            'type': 'int', 'value': 2**len(_ct.SR_STATUS_LABELS)-1,
+            'unit': '2^_PS_PU_RF_TI'},
         'DiagStatusBOLabels-Cte': {
             'type': 'char', 'count': 1000,
             'value': '\n'.join(_ct.SR_STATUS_LABELS)},
         'DiagStatusTS-Mon': {
-            'type': 'int', 'value': 2**len(_ct.TL_STATUS_LABELS)-1},
+            'type': 'int', 'value': 2**len(_ct.TL_STATUS_LABELS)-1,
+            'unit': '2^_PS_PU_TI'},
         'DiagStatusTSLabels-Cte': {
             'type': 'char', 'count': 1000,
             'value': '\n'.join(_ct.TL_STATUS_LABELS)},
         'DiagStatusSI-Mon': {
-            'type': 'int', 'value': 2**len(_ct.SR_STATUS_LABELS)-1},
+            'type': 'int', 'value': 2**len(_ct.SR_STATUS_LABELS)-1,
+            'unit': '2^_PS_PU_RF_TI'},
         'DiagStatusSILabels-Cte': {
             'type': 'char', 'count': 1000,
             'value': '\n'.join(_ct.SR_STATUS_LABELS)},
         'DiagStatusAS-Mon': {
-            'type': 'int', 'value': 2**len(_ct.AS_STATUS_LABELS)-1},
+            'type': 'int', 'value': 2**len(_ct.AS_STATUS_LABELS)-1,
+            'unit': '2^_TI'},
         'DiagStatusASLabels-Cte': {
             'type': 'char', 'count': 1000,
             'value': '\n'.join(_ct.AS_STATUS_LABELS)},
         'DiagStatus-Mon': {
-            'type': 'int', 'value': 2**len(_ct.GEN_STATUS_LABELS)-1},
+            'type': 'int', 'value': 2**len(_ct.GEN_STATUS_LABELS)-1,
+            'unit': '2^_LI_TB_BO_TS_SI_AS'},
         'DiagStatusLabels-Cte': {
             'type': 'char', 'count': 1000,
             'value': '\n'.join(_ct.GEN_STATUS_LABELS)},
         'InjStatus-Mon': {
-            'type': 'int', 'value': 2**len(_ct.INJ_STATUS_LABELS)-1},
+            'type': 'int', 'value': 2**len(_ct.INJ_STATUS_LABELS)-1,
+            'unit': '2^Evt_BucL_Bias_Fila_HV_Pulse_Trig_InjS'},
         'InjStatusLabels-Cte': {
             'type': 'char', 'count': 1000,
             'value': '\n'.join(_ct.INJ_STATUS_LABELS)},
@@ -303,9 +312,11 @@ def get_biasfb_database():
     """."""
     dbase = {
         'LoopState-Sel': {
-            'type': 'enum', 'value': _ct.OffOn.Off, 'enums': _et.OFF_ON},
+            'type': 'enum', 'value': _ct.OffOn.Off, 'enums': _et.OFF_ON,
+            'unit': 'Off_On'},
         'LoopState-Sts': {
-            'type': 'enum', 'value': _ct.TopUpSts.Off, 'enums': _et.TOPUPSTS},
+            'type': 'enum', 'value': _ct.OffOn.Off, 'enums': _et.OFF_ON,
+            'unit': 'Off_On'},
         'MinVoltage-SP': {
             'type': 'float', 'value': -52, 'unit': 'V',
             'prec': 1, 'lolim': -120, 'low': -120, 'lolo': -120,
@@ -325,10 +336,10 @@ def get_biasfb_database():
 
         'ModelType-Sel': {
             'type': 'enum', 'value': _ct.BiasFBModelTypes.GaussianProcess,
-            'enums': _et.BIASFB_MODEL_TYPES},
+            'enums': _et.BIASFB_MODEL_TYPES, 'unit': 'Lin_GP'},
         'ModelType-Sts': {
             'type': 'enum', 'value': _ct.BiasFBModelTypes.GaussianProcess,
-            'enums': _et.BIASFB_MODEL_TYPES},
+            'enums': _et.BIASFB_MODEL_TYPES, 'unit': 'Lin_GP'},
         'ModelMaxNumPts-SP': {
             'type': 'int', 'value': 20, 'unit': '#',
             'lolim': 2, 'low': 2, 'lolo': 2,
@@ -349,9 +360,11 @@ def get_biasfb_database():
             'hihi': _ct.BIASFB_MAX_DATA_SIZE},
         'ModelFitParamsNow-Cmd': {'type': 'int', 'value': 0},
         'ModelAutoFitParams-Sel': {
-            'type': 'enum', 'value': _ct.OffOn.Off, 'enums': _et.OFF_ON},
+            'type': 'enum', 'value': _ct.OffOn.Off, 'enums': _et.OFF_ON,
+            'unit': 'Off_On'},
         'ModelAutoFitParams-Sts': {
-            'type': 'enum', 'value': _ct.OffOn.Off, 'enums': _et.OFF_ON},
+            'type': 'enum', 'value': _ct.OffOn.Off, 'enums': _et.OFF_ON,
+            'unit': 'Off_On'},
         'ModelAutoFitEveryNumPts-SP': {
             'type': 'int', 'value': 10, 'unit': '#',
             'lolim': 1, 'low': 1, 'lolo': 1,
@@ -371,9 +384,11 @@ def get_biasfb_database():
             'high': _ct.BIASFB_MAX_DATA_SIZE,
             'hihi': _ct.BIASFB_MAX_DATA_SIZE},
         'ModelUpdateData-Sel': {
-            'type': 'enum', 'value': _ct.OffOn.Off, 'enums': _et.OFF_ON},
+            'type': 'enum', 'value': _ct.OffOn.Off, 'enums': _et.OFF_ON,
+            'unit': 'Off_On'},
         'ModelUpdateData-Sts': {
-            'type': 'enum', 'value': _ct.OffOn.Off, 'enums': _et.OFF_ON},
+            'type': 'enum', 'value': _ct.OffOn.Off, 'enums': _et.OFF_ON,
+            'unit': 'Off_On'},
         'ModelDataBias-SP': {
             'type': 'float', 'count': _ct.BIASFB_MAX_DATA_SIZE,
             'value': [0]*_ct.BIASFB_MAX_DATA_SIZE, 'unit': 'V'},

--- a/siriuspy/siriuspy/injctrl/csdev.py
+++ b/siriuspy/siriuspy/injctrl/csdev.py
@@ -207,7 +207,8 @@ def get_injctrl_propty_database():
             'lolim': -_ct.MAX_BKT+1, 'hilim': _ct.MAX_BKT-1},
 
         'TopUpState-Sel': {
-            'type': 'enum', 'value': _ct.OffOn.Off, 'enums': _et.OFF_ON, 'unit': 'Off_On'},
+            'type': 'enum', 'value': _ct.OffOn.Off,
+            'enums': _et.OFF_ON, 'unit': 'Off_On'},
         'TopUpState-Sts': {
             'type': 'enum', 'value': _ct.TopUpSts.Off, 'enums': _et.TOPUPSTS,
             'unit': 'Off_Wai_TOn_Inj_TOff_Skip'},

--- a/siriuspy/siriuspy/injctrl/csdev.py
+++ b/siriuspy/siriuspy/injctrl/csdev.py
@@ -18,6 +18,7 @@ class ETypes(_csdev.ETypes):
     INJSYSCMDSTS = ('Idle', 'On', 'Off')
     RFKILLBEAMMON = ('Idle', 'Kill')
     IDLERUNNING = ('Idle', 'Running')
+    BIASFB_MODEL_TYPES = ('Linear', 'GaussianProcess')
 
 
 _et = ETypes
@@ -37,6 +38,8 @@ class Const(_csdev.Const):
     InjSysCmdSts = _csdev.Const.register('InjSysCmdSts', _et.INJSYSCMDSTS)
     RFKillBeamMon = _csdev.Const.register('RFKillBeamMon', _et.RFKILLBEAMMON)
     IdleRunning = _csdev.Const.register('IdleRunning', _et.IDLERUNNING)
+    BiasFBModelTypes = _csdev.Const.register(
+        'ModelTypes', _et.BIASFB_MODEL_TYPES)
 
     GEN_STATUS_LABELS = ('LI', 'TB', 'BO', 'TS', 'SI', 'AS')
     LI_STATUS_LABELS = ('Egun', 'PS', 'PU', 'RF', 'TI')
@@ -70,6 +73,9 @@ class Const(_csdev.Const):
     INJSYS_DEF_OFF_ORDER = ['bo_rf', 'li_rf', 'injbo', 'as_pu', 'bo_ps']
 
     PU_VOLTAGE_UP_TIME = 30  # [s]
+
+    BIASFB_AHEADSETIME = 10  # [s]
+    BIASFB_MINIMUM_LIFETIME = 1800  # [s]
 
 
 _ct = Const

--- a/siriuspy/siriuspy/injctrl/csdev.py
+++ b/siriuspy/siriuspy/injctrl/csdev.py
@@ -76,6 +76,7 @@ class Const(_csdev.Const):
 
     BIASFB_AHEADSETIME = 10  # [s]
     BIASFB_MINIMUM_LIFETIME = 1800  # [s]
+    BIASFB_PROPTY_PREFIX = 'BiasFB'
 
 
 _ct = Const
@@ -295,3 +296,174 @@ def get_injctrl_propty_database():
     }
     dbase = _csdev.add_pvslist_cte(dbase)
     return dbase
+
+
+def get_biasfb_database():
+    """."""
+    dbase = {
+        'LoopState-Sel': {
+            'type': 'enum', 'value': _ct.OffOn.Off, 'enums': _et.OFF_ON},
+        'LoopState-Sts': {
+            'type': 'enum', 'value': _ct.TopUpSts.Off, 'enums': _et.TOPUPSTS},
+        'MinVoltage-SP': {
+            'type': 'float', 'value': -52, 'unit': 'V',
+            'prec': 1, 'lolim': -120, 'low': -120, 'lolo': -120,
+            'hilim': -30.0, 'high': -30.0, 'hihi': -30.0},
+        'MinVoltage-RB': {
+            'type': 'float', 'value': -52, 'unit': 'V',
+            'prec': 1, 'lolim': -120, 'low': -120, 'lolo': -120,
+            'hilim': -30.0, 'high': -30.0, 'hihi': -30.0},
+        'MaxVoltage-SP': {
+            'type': 'float', 'value': -52, 'unit': 'V',
+            'prec': 1, 'lolim': -120, 'low': -120, 'lolo': -120,
+            'hilim': -30.0, 'high': -30.0, 'hihi': -30.0},
+        'MaxVoltage-RB': {
+            'type': 'float', 'value': -52, 'unit': 'V',
+            'prec': 1, 'lolim': -120, 'low': -120, 'lolo': -120,
+            'hilim': -30.0, 'high': -30.0, 'hihi': -30.0},
+
+        'ModelType-Sel': {
+            'type': 'enum', 'value': _ct.BiasFBModelTypes.GaussianProcess,
+            'enums': _et.BIASFB_MODEL_TYPES},
+        'ModelType-Sts': {
+            'type': 'enum', 'value': _ct.BiasFBModelTypes.GaussianProcess,
+            'enums': _et.BIASFB_MODEL_TYPES},
+        'ModelMaxNumPts-SP': {
+            'type': 'int', 'value': 20, 'unit': '#',
+            'lolim': 2, 'low': 2, 'lolo': 2,
+            'hilim': 1000, 'high': 1000, 'hihi': 1000},
+        'ModelMaxNumPts-RB': {
+            'type': 'int', 'value': 20, 'unit': '#',
+            'lolim': 0, 'low': 0, 'lolo': 0,
+            'hilim': 1000, 'high': 1000, 'hihi': 1000},
+        'ModelNumPts-Mon': {
+            'type': 'int', 'value': 20, 'unit': '#',
+            'lolim': 2, 'low': 2, 'lolo': 2,
+            'hilim': 1000, 'high': 1000, 'hihi': 1000},
+        'ModelFitParamsNow-Cmd': {'type': 'int', 'value': 0},
+        'ModelAutoFitParams-Sel': {
+            'type': 'enum', 'value': _ct.OffOn.Off, 'enums': _et.OFF_ON},
+        'ModelAutoFitParams-Sts': {
+            'type': 'enum', 'value': _ct.OffOn.Off, 'enums': _et.OFF_ON},
+        'ModelAutoFitEveryNumPts-SP': {
+            'type': 'int', 'value': 10, 'unit': '#',
+            'lolim': 1, 'low': 1, 'lolo': 1,
+            'hilim': 1000, 'high': 1000, 'hihi': 1000},
+        'ModelAutoFitEveryNumPts-RB': {
+            'type': 'int', 'value': 10, 'unit': '#',
+            'lolim': 1, 'low': 1, 'lolo': 1,
+            'hilim': 1000, 'high': 1000, 'hihi': 1000},
+        'ModelNumPtsAfterFit-Mon': {
+            'type': 'int', 'value': 10, 'unit': '#',
+            'lolim': 1, 'low': 1, 'lolo': 1,
+            'hilim': 1000, 'high': 1000, 'hihi': 1000},
+        'ModelUpdateData-Sel': {
+            'type': 'enum', 'value': _ct.OffOn.Off, 'enums': _et.OFF_ON},
+        'ModelUpdateData-Sts': {
+            'type': 'enum', 'value': _ct.OffOn.Off, 'enums': _et.OFF_ON},
+        'ModelDataBias-SP': {
+            'type': 'float', 'count': 1000, 'value': [0]*1000},
+        'ModelDataBias-RB': {
+            'type': 'float', 'count': 1000, 'value': [0]*1000},
+        'ModelDataBias-Mon': {
+            'type': 'float', 'count': 1000, 'value': [0]*1000},
+        'ModelDataInjCurr-SP': {
+            'type': 'float', 'count': 1000, 'value': [0]*1000},
+        'ModelDataInjCurr-RB': {
+            'type': 'float', 'count': 1000, 'value': [0]*1000},
+        'ModelDataInjCurr-Mon': {
+            'type': 'float', 'count': 1000, 'value': [0]*1000},
+
+        'LinModAngCoeff-SP': {
+            'type': 'float', 'value': 10, 'unit': 'V/mA',
+            'prec': 2, 'lolim': 0.1, 'low': 0.1, 'lolo': 0.1,
+            'hilim': 30.0, 'high': 30.0, 'hihi': 30.0},
+        'LinModAngCoeff-RB': {
+            'type': 'float', 'value': 10, 'unit': 'V/mA',
+            'prec': 2, 'lolim': 0.1, 'low': 0.1, 'lolo': 0.1,
+            'hilim': 30.0, 'high': 30.0, 'hihi': 30.0},
+        'LinModAngCoeff-Mon': {
+            'type': 'float', 'value': 10, 'unit': 'V/mA',
+            'prec': 2, 'lolim': 0.1, 'low': 0.1, 'lolo': 0.1,
+            'hilim': 30.0, 'high': 30.0, 'hihi': 30.0},
+        'LinModOffCoeff-SP': {
+            'type': 'float', 'value': 10, 'unit': 'V/mA',
+            'prec': 2, 'lolim': -120, 'low': -120, 'lolo': -120,
+            'hilim': -30.0, 'high': -30.0, 'hihi': -30.0},
+        'LinModOffCoeff-RB': {
+            'type': 'float', 'value': 10, 'unit': 'V/mA',
+            'prec': 2, 'lolim': -120, 'low': -120, 'lolo': -120,
+            'hilim': -30.0, 'high': -30.0, 'hihi': -30.0},
+        'LinModOffCoeff-Mon': {
+            'type': 'float', 'value': 10, 'unit': 'V/mA',
+            'prec': 2, 'lolim': -120, 'low': -120, 'lolo': -120,
+            'hilim': -30.0, 'high': -30.0, 'hihi': -30.0},
+
+        # These are used to give the model inference about the bias
+        # Generally ploted in Injcurr X Bias graphs
+        'LinModInferenceInjCurr-Mon': {
+            'type': 'float', 'count': 100, 'value': [0]*100},
+        'LinModInferenceBias-Mon': {
+            'type': 'float', 'count': 100, 'value': [0]*100},
+
+        # These are used to give the model prediction about current
+        # Generally ploted in Bias x InjCurr graphs to check model sanity
+        'LinModPredBias-Mon': {
+            'type': 'float', 'count': 100, 'value': [0]*100},
+        'LinModPredInjCurrAvg-Mon': {
+            'type': 'float', 'count': 100, 'value': [0]*100},
+
+        'GPModNoiseVar-SP': {
+            'type': 'float', 'value': 0.05**2, 'unit': 'mA^2', 'prec': 6,
+            'lolim': 0.005**2, 'low': 0.005**2, 'lolo': 0.005**2,
+            'hilim': 0.5**2, 'high': 0.5**2, 'hihi': 0.5**2},
+        'GPModNoiseVar-RB': {
+            'type': 'float', 'value': 0.4**2, 'unit': 'mA^2', 'prec': 6,
+            'lolim': 0.05**2, 'low': 0.05**2, 'lolo': 0.05**2,
+            'hilim': 1**2, 'high': 1**2, 'hihi': 1**2},
+        'GPModNoiseVar-Mon': {
+            'type': 'float', 'value': 0.4**2, 'unit': 'mA^2', 'prec': 6,
+            'lolim': 0.05**2, 'low': 0.05**2, 'lolo': 0.05**2,
+            'hilim': 1**2, 'high': 1**2, 'hihi': 1**2},
+        'GPModKernVar-SP': {
+            'type': 'float', 'value': 0.4**2, 'unit': 'mA^2', 'prec': 6,
+            'lolim': 0.05**2, 'low': 0.05**2, 'lolo': 0.05**2,
+            'hilim': 1**2, 'high': 1**2, 'hihi': 1**2},
+        'GPModKernVar-RB': {
+            'type': 'float', 'value': 0.4**2, 'unit': 'mA^2', 'prec': 6,
+            'lolim': 0.05**2, 'low': 0.05**2, 'lolo': 0.05**2,
+            'hilim': 1**2, 'high': 1**2, 'hihi': 1**2},
+        'GPModKernVar-Mon': {
+            'type': 'float', 'value': 0.4**2, 'unit': 'mA^2', 'prec': 6,
+            'lolim': 0.05**2, 'low': 0.05**2, 'lolo': 0.05**2,
+            'hilim': 1**2, 'high': 1**2, 'hihi': 1**2},
+        'GPModKernLenScl-SP': {
+            'type': 'float', 'value': 5, 'unit': 'V', 'prec': 3,
+            'lolim': 1, 'low': 1, 'lolo': 1,
+            'hilim': 10, 'high': 10, 'hihi': 10},
+        'GPModKernLenScl-RB': {
+            'type': 'float', 'value': 5, 'unit': 'V', 'prec': 3,
+            'lolim': 1, 'low': 1, 'lolo': 1,
+            'hilim': 10, 'high': 10, 'hihi': 10},
+        'GPModKernLenScl-Mon': {
+            'type': 'float', 'value': 5, 'unit': 'V', 'prec': 3,
+            'lolim': 1, 'low': 1, 'lolo': 1,
+            'hilim': 10, 'high': 10, 'hihi': 10},
+
+        # These are used to give the model inference about the bias
+        # Generally ploted in Injcurr X Bias graphs
+        'GPModInferenceInjCurr-Mon': {
+            'type': 'float', 'count': 100, 'value': [0]*100},
+        'GPModInferenceBias-Mon': {
+            'type': 'float', 'count': 100, 'value': [0]*100},
+
+        # These are used to give the model prediction about current
+        # Generally ploted in Bias x InjCurr graphs to check model sanity
+        'GPModPredBias-Mon': {
+            'type': 'float', 'count': 100, 'value': [0]*100},
+        'GPModPredInjCurrAvg-Mon': {
+            'type': 'float', 'count': 100, 'value': [0]*100},
+        'GPModPredInjCurrStd-Mon': {
+            'type': 'float', 'count': 100, 'value': [0]*100},
+        }
+    return {_ct.BIASFB_PROPTY_PREFIX+k: v for k, v in dbase.items()}

--- a/siriuspy/siriuspy/injctrl/csdev.py
+++ b/siriuspy/siriuspy/injctrl/csdev.py
@@ -447,30 +447,30 @@ def get_biasfb_database():
         'LinModPredInjCurrAvg-Mon': {
             'type': 'float', 'count': 100, 'value': [0]*100, 'unit': 'mA'},
 
-        'GPModNoiseVar-SP': {
-            'type': 'float', 'value': 0.05**2, 'unit': 'mA^2', 'prec': 6,
-            'lolim': 0.005**2, 'low': 0.005**2, 'lolo': 0.005**2,
-            'hilim': 0.5**2, 'high': 0.5**2, 'hihi': 0.5**2},
-        'GPModNoiseVar-RB': {
-            'type': 'float', 'value': 0.05**2, 'unit': 'mA^2', 'prec': 6,
-            'lolim': 0.005**2, 'low': 0.005**2, 'lolo': 0.005**2,
-            'hilim': 0.5**2, 'high': 0.5**2, 'hihi': 0.5**2},
-        'GPModNoiseVar-Mon': {
-            'type': 'float', 'value': 0.05**2, 'unit': 'mA^2', 'prec': 6,
-            'lolim': 0.005**2, 'low': 0.005**2, 'lolo': 0.005**2,
-            'hilim': 0.5**2, 'high': 0.5**2, 'hihi': 0.5**2},
-        'GPModKernVar-SP': {
-            'type': 'float', 'value': 0.4**2, 'unit': 'mA^2', 'prec': 6,
-            'lolim': 0.05**2, 'low': 0.05**2, 'lolo': 0.05**2,
-            'hilim': 1**2, 'high': 1**2, 'hihi': 1**2},
-        'GPModKernVar-RB': {
-            'type': 'float', 'value': 0.4**2, 'unit': 'mA^2', 'prec': 6,
-            'lolim': 0.05**2, 'low': 0.05**2, 'lolo': 0.05**2,
-            'hilim': 1**2, 'high': 1**2, 'hihi': 1**2},
-        'GPModKernVar-Mon': {
-            'type': 'float', 'value': 0.4**2, 'unit': 'mA^2', 'prec': 6,
-            'lolim': 0.05**2, 'low': 0.05**2, 'lolo': 0.05**2,
-            'hilim': 1**2, 'high': 1**2, 'hihi': 1**2},
+        'GPModNoiseStd-SP': {
+            'type': 'float', 'value': 0.05, 'unit': 'mA', 'prec': 4,
+            'lolim': 0.005, 'low': 0.005, 'lolo': 0.005,
+            'hilim': 0.5, 'high': 0.5, 'hihi': 0.5},
+        'GPModNoiseStd-RB': {
+            'type': 'float', 'value': 0.05, 'unit': 'mA', 'prec': 4,
+            'lolim': 0.005, 'low': 0.005, 'lolo': 0.005,
+            'hilim': 0.5, 'high': 0.5, 'hihi': 0.5},
+        'GPModNoiseStd-Mon': {
+            'type': 'float', 'value': 0.05, 'unit': 'mA', 'prec': 4,
+            'lolim': 0.005, 'low': 0.005, 'lolo': 0.005,
+            'hilim': 0.5, 'high': 0.5, 'hihi': 0.5},
+        'GPModKernStd-SP': {
+            'type': 'float', 'value': 0.4, 'unit': 'mA', 'prec': 3,
+            'lolim': 0.05, 'low': 0.05, 'lolo': 0.05,
+            'hilim': 1, 'high': 1, 'hihi': 1},
+        'GPModKernStd-RB': {
+            'type': 'float', 'value': 0.4, 'unit': 'mA', 'prec': 3,
+            'lolim': 0.05, 'low': 0.05, 'lolo': 0.05,
+            'hilim': 1, 'high': 1, 'hihi': 1},
+        'GPModKernStd-Mon': {
+            'type': 'float', 'value': 0.4, 'unit': 'mA', 'prec': 3,
+            'lolim': 0.05, 'low': 0.05, 'lolo': 0.05,
+            'hilim': 1, 'high': 1, 'hihi': 1},
         'GPModKernLenScl-SP': {
             'type': 'float', 'value': 5, 'unit': 'V', 'prec': 3,
             'lolim': 1, 'low': 1, 'lolo': 1,

--- a/siriuspy/siriuspy/injctrl/csdev.py
+++ b/siriuspy/siriuspy/injctrl/csdev.py
@@ -376,22 +376,22 @@ def get_biasfb_database():
             'type': 'enum', 'value': _ct.OffOn.Off, 'enums': _et.OFF_ON},
         'ModelDataBias-SP': {
             'type': 'float', 'count': _ct.BIASFB_MAX_DATA_SIZE,
-            'value': [0]*_ct.BIASFB_MAX_DATA_SIZE},
+            'value': [0]*_ct.BIASFB_MAX_DATA_SIZE, 'unit': 'V'},
         'ModelDataBias-RB': {
             'type': 'float', 'count': _ct.BIASFB_MAX_DATA_SIZE,
-            'value': [0]*_ct.BIASFB_MAX_DATA_SIZE},
+            'value': [0]*_ct.BIASFB_MAX_DATA_SIZE, 'unit': 'V'},
         'ModelDataBias-Mon': {
             'type': 'float', 'count': _ct.BIASFB_MAX_DATA_SIZE,
-            'value': [0]*_ct.BIASFB_MAX_DATA_SIZE},
+            'value': [0]*_ct.BIASFB_MAX_DATA_SIZE, 'unit': 'V'},
         'ModelDataInjCurr-SP': {
             'type': 'float', 'count': _ct.BIASFB_MAX_DATA_SIZE,
-            'value': [0]*_ct.BIASFB_MAX_DATA_SIZE},
+            'value': [0]*_ct.BIASFB_MAX_DATA_SIZE, 'unit': 'mA'},
         'ModelDataInjCurr-RB': {
             'type': 'float', 'count': _ct.BIASFB_MAX_DATA_SIZE,
-            'value': [0]*_ct.BIASFB_MAX_DATA_SIZE},
+            'value': [0]*_ct.BIASFB_MAX_DATA_SIZE, 'unit': 'mA'},
         'ModelDataInjCurr-Mon': {
             'type': 'float', 'count': _ct.BIASFB_MAX_DATA_SIZE,
-            'value': [0]*_ct.BIASFB_MAX_DATA_SIZE},
+            'value': [0]*_ct.BIASFB_MAX_DATA_SIZE, 'unit': 'mA'},
 
         'LinModAngCoeff-SP': {
             'type': 'float', 'value': 10, 'unit': 'V/mA',
@@ -421,16 +421,16 @@ def get_biasfb_database():
         # These are used to give the model inference about the bias
         # Generally ploted in Injcurr X Bias graphs
         'LinModInferenceInjCurr-Mon': {
-            'type': 'float', 'count': 100, 'value': [0]*100},
+            'type': 'float', 'count': 100, 'value': [0]*100, 'unit': 'mA'},
         'LinModInferenceBias-Mon': {
-            'type': 'float', 'count': 100, 'value': [0]*100},
+            'type': 'float', 'count': 100, 'value': [0]*100, 'unit': 'V'},
 
         # These are used to give the model prediction about current
         # Generally ploted in Bias x InjCurr graphs to check model sanity
         'LinModPredBias-Mon': {
-            'type': 'float', 'count': 100, 'value': [0]*100},
+            'type': 'float', 'count': 100, 'value': [0]*100, 'unit': 'V'},
         'LinModPredInjCurrAvg-Mon': {
-            'type': 'float', 'count': 100, 'value': [0]*100},
+            'type': 'float', 'count': 100, 'value': [0]*100, 'unit': 'mA'},
 
         'GPModNoiseVar-SP': {
             'type': 'float', 'value': 0.05**2, 'unit': 'mA^2', 'prec': 6,
@@ -472,17 +472,17 @@ def get_biasfb_database():
         # These are used to give the model inference about the bias
         # Generally ploted in Injcurr X Bias graphs
         'GPModInferenceInjCurr-Mon': {
-            'type': 'float', 'count': 100, 'value': [0]*100},
+            'type': 'float', 'count': 100, 'value': [0]*100, 'unit': 'mA'},
         'GPModInferenceBias-Mon': {
-            'type': 'float', 'count': 100, 'value': [0]*100},
+            'type': 'float', 'count': 100, 'value': [0]*100, 'unit': 'V'},
 
         # These are used to give the model prediction about current
         # Generally ploted in Bias x InjCurr graphs to check model sanity
         'GPModPredBias-Mon': {
-            'type': 'float', 'count': 100, 'value': [0]*100},
+            'type': 'float', 'count': 100, 'value': [0]*100, 'unit': 'V'},
         'GPModPredInjCurrAvg-Mon': {
-            'type': 'float', 'count': 100, 'value': [0]*100},
+            'type': 'float', 'count': 100, 'value': [0]*100, 'unit': 'mA'},
         'GPModPredInjCurrStd-Mon': {
-            'type': 'float', 'count': 100, 'value': [0]*100},
+            'type': 'float', 'count': 100, 'value': [0]*100, 'unit': 'mA'},
         }
     return {_ct.BIASFB_PROPTY_PREFIX+k: v for k, v in dbase.items()}

--- a/siriuspy/siriuspy/injctrl/csdev.py
+++ b/siriuspy/siriuspy/injctrl/csdev.py
@@ -421,15 +421,15 @@ def get_biasfb_database():
             'prec': 2, 'lolim': 0.1, 'low': 0.1, 'lolo': 0.1,
             'hilim': 30.0, 'high': 30.0, 'hihi': 30.0},
         'LinModOffCoeff-SP': {
-            'type': 'float', 'value': 10, 'unit': 'V/mA',
+            'type': 'float', 'value': -52, 'unit': 'V/mA',
             'prec': 2, 'lolim': -120, 'low': -120, 'lolo': -120,
             'hilim': -30.0, 'high': -30.0, 'hihi': -30.0},
         'LinModOffCoeff-RB': {
-            'type': 'float', 'value': 10, 'unit': 'V/mA',
+            'type': 'float', 'value': -52, 'unit': 'V/mA',
             'prec': 2, 'lolim': -120, 'low': -120, 'lolo': -120,
             'hilim': -30.0, 'high': -30.0, 'hihi': -30.0},
         'LinModOffCoeff-Mon': {
-            'type': 'float', 'value': 10, 'unit': 'V/mA',
+            'type': 'float', 'value': -52, 'unit': 'V/mA',
             'prec': 2, 'lolim': -120, 'low': -120, 'lolo': -120,
             'hilim': -30.0, 'high': -30.0, 'hihi': -30.0},
 

--- a/siriuspy/siriuspy/injctrl/main.py
+++ b/siriuspy/siriuspy/injctrl/main.py
@@ -230,7 +230,9 @@ class App(_Callback):
         # Create object to make bias feedback:
         self._bias_feedback = _BiasFeedback(self)
         self._pvs_database.update(self._bias_feedback.database)
-        self.map_pv2write.update(self._bias_feedback.map_pv2write)
+        for prop, write in self._bias_feedback.map_pv2write.items():
+            pvname = _Const.BIASFB_PROPTY_PREFIX + prop
+            self.map_pv2write[pvname] = write
 
     def init_database(self):
         """Set initial PV values."""

--- a/siriuspy/siriuspy/injctrl/main.py
+++ b/siriuspy/siriuspy/injctrl/main.py
@@ -20,6 +20,7 @@ from ..devices import InjSysStandbyHandler, EVG, EGun, CurrInfoSI, \
 from .csdev import Const as _Const, ETypes as _ETypes, \
     get_injctrl_propty_database as _get_database, \
     get_status_labels as _get_sts_lbls
+from .bias_feedback import BiasFeedback as _BiasFeedback
 
 
 class App(_Callback):
@@ -134,11 +135,13 @@ class App(_Callback):
                     n: _PV(n+':DiagStatus-Mon', connection_timeout=0.05)
                     for n in _RFDiagConst.ALL_DEVICES if n.startswith(sec)}
 
+        self._bias_feedback = _BiasFeedback(self)
+
         # auxiliary devices
-        self._egun_dev = EGun(
+        self.egun_dev = EGun(
             print_log=False, callback=self._update_dev_status)
         self._init_egun = False
-        self._egun_dev.trigps.pv_object('enable').add_callback(
+        self.egun_dev.trigps.pv_object('enable').add_callback(
             self._callback_watch_eguntrig)
 
         self._pumode_dev = InjSysPUModeHandler(
@@ -153,9 +156,9 @@ class App(_Callback):
 
         self._injsys_dev = InjSysStandbyHandler()
 
-        self._currinfo_dev = CurrInfoSI()
-        self._currinfo_dev.set_auto_monitor('Current-Mon', True)
-        curr_pvo = self._currinfo_dev.pv_object('Current-Mon')
+        self.currinfo_dev = CurrInfoSI()
+        self.currinfo_dev.set_auto_monitor('Current-Mon', True)
+        curr_pvo = self.currinfo_dev.pv_object('Current-Mon')
         curr_pvo.add_callback(self._callback_autostop)
         curr_pvo.connection_callbacks.append(self._callback_conn_autostop)
 
@@ -207,47 +210,47 @@ class App(_Callback):
         self.thread_check_injstatus.start()
 
         # initialize default operation values with implemented values
-        self._egun_dev.wait_for_connection()
-        biasvolt = self._egun_dev.bias.voltage
+        self.egun_dev.wait_for_connection()
+        biasvolt = self.egun_dev.bias.voltage
         if biasvolt is None:
             self._sglbunbiasvolt = _Const.BIAS_SINGLE_BUNCH
             self._multbunbiasvolt = _Const.BIAS_MULTI_BUNCH
         else:
             self._sglbunbiasvolt = biasvolt
             self._multbunbiasvolt = biasvolt
-            self._egun_dev.single_bunch_bias_voltage = biasvolt
-            self._egun_dev.multi_bunch_bias_voltage = biasvolt
-        filacurr = self._egun_dev.fila.current
+            self.egun_dev.single_bunch_bias_voltage = biasvolt
+            self.egun_dev.multi_bunch_bias_voltage = biasvolt
+        filacurr = self.egun_dev.fila.current
         if filacurr is None:
             self._filaopcurr = _Const.FILACURR_OPVALUE
         else:
             self._filaopcurr = filacurr
-            self._egun_dev.fila_current_opvalue = filacurr
-        hvvolt = self._egun_dev.hvps.voltage
+            self.egun_dev.fila_current_opvalue = filacurr
+        hvvolt = self.egun_dev.hvps.voltage
         if hvvolt is None:
             self._hvopvolt = _Const.HV_OPVALUE
         else:
             self._hvopvolt = hvvolt
-            self._egun_dev.high_voltage_opvalue = hvvolt
+            self.egun_dev.high_voltage_opvalue = hvvolt
 
     def init_database(self):
         """Set initial PV values."""
         self.run_callbacks('Mode-Sel', self._mode)
         self.run_callbacks('Mode-Sts', self._mode)
         self._callback_update_type(init=True)
-        self._egun_dev.pulse.pv_object('multiselstatus').add_callback(
+        self.egun_dev.pulse.pv_object('multiselstatus').add_callback(
             self._callback_update_type)
-        self._egun_dev.pulse.pv_object('multiswstatus').add_callback(
+        self.egun_dev.pulse.pv_object('multiswstatus').add_callback(
             self._callback_update_type)
-        self._egun_dev.pulse.pv_object('singleselstatus').add_callback(
+        self.egun_dev.pulse.pv_object('singleselstatus').add_callback(
             self._callback_update_type)
-        self._egun_dev.pulse.pv_object('singleswstatus').add_callback(
+        self.egun_dev.pulse.pv_object('singleswstatus').add_callback(
             self._callback_update_type)
-        self._egun_dev.trigmultipre.pv_object('State-Sts').add_callback(
+        self.egun_dev.trigmultipre.pv_object('State-Sts').add_callback(
             self._callback_update_type)
-        self._egun_dev.trigmulti.pv_object('State-Sts').add_callback(
+        self.egun_dev.trigmulti.pv_object('State-Sts').add_callback(
             self._callback_update_type)
-        self._egun_dev.trigsingle.pv_object('State-Sts').add_callback(
+        self.egun_dev.trigsingle.pv_object('State-Sts').add_callback(
             self._callback_update_type)
         self.run_callbacks('TypeCmdSts-Mon', self._p2w['Type']['status'])
         self.run_callbacks('SglBunBiasVolt-SP', self._sglbunbiasvolt)
@@ -370,15 +373,15 @@ class App(_Callback):
         if self._p2w['Type']['watcher'] is not None and \
                 self._p2w['Type']['watcher'].is_alive():
             self._update_log('WARN:Interrupting type change command..')
-            self._egun_dev.cmd_abort_chg_type()
+            self.egun_dev.cmd_abort_chg_type()
             self._p2w['Type']['watcher'].join()
 
         self._type = value
         self.run_callbacks('Type-Sts', self._type)
 
-        target = self._egun_dev.cmd_switch_to_single_bunch \
+        target = self.egun_dev.cmd_switch_to_single_bunch \
             if value == _Const.InjType.SingleBunch else \
-            self._egun_dev.cmd_switch_to_multi_bunch
+            self.egun_dev.cmd_switch_to_multi_bunch
         self._p2w['Type']['watcher'] = _epics.ca.CAThread(
             target=target, daemon=True)
         self._p2w['Type']['watcher'].start()
@@ -391,7 +394,7 @@ class App(_Callback):
     def set_sglbunbiasvolt(self, value):
         """Set single bunch bias voltage."""
         self._update_log('Received setpoint to SB Bias voltage.')
-        self._egun_dev.single_bunch_bias_voltage = value
+        self.egun_dev.single_bunch_bias_voltage = value
         self._sglbunbiasvolt = value
         self.run_callbacks('SglBunBiasVolt-RB', self._sglbunbiasvolt)
 
@@ -403,7 +406,7 @@ class App(_Callback):
     def set_multbunbiasvolt(self, value):
         """Set multi bunch bias voltage."""
         self._update_log('Received setpoint to MB Bias voltage.')
-        self._egun_dev.multi_bunch_bias_voltage = value
+        self.egun_dev.multi_bunch_bias_voltage = value
         self._multbunbiasvolt = value
         self.run_callbacks('MultBunBiasVolt-RB', self._multbunbiasvolt)
 
@@ -416,7 +419,7 @@ class App(_Callback):
         self.run_callbacks('BiasVoltCmdSts-Mon', _Const.IdleRunning.Running)
 
         self._update_log('Setting EGun Bias voltage to {}V...'.format(value))
-        if not self._egun_dev.bias.set_voltage(value):
+        if not self.egun_dev.bias.set_voltage(value):
             self._update_log('ERR:Could not set EGun Bias voltage.')
         else:
             self._update_log('Set EGun Bias voltage: {}V.'.format(value))
@@ -428,15 +431,15 @@ class App(_Callback):
         if self._p2w['FilaOpCurr']['watcher'] is not None and \
                 self._p2w['FilaOpCurr']['watcher'].is_alive():
             self._update_log('WARN:Interrupting FilaPS current ramp...')
-            self._egun_dev.cmd_abort_rmp_fila()
+            self.egun_dev.cmd_abort_rmp_fila()
             self._p2w['FilaOpCurr']['watcher'].join()
 
-        self._egun_dev.fila_current_opvalue = value
+        self.egun_dev.fila_current_opvalue = value
         self._filaopcurr = value
         self.run_callbacks('FilaOpCurr-RB', self._filaopcurr)
 
         self._p2w['FilaOpCurr']['watcher'] = _epics.ca.CAThread(
-            target=self._egun_dev.set_fila_current, daemon=True)
+            target=self.egun_dev.set_fila_current, daemon=True)
         self._p2w['FilaOpCurr']['watcher'].start()
         self._p2w['FilaOpCurr']['status'] = _Const.IdleRunning.Running
         self.run_callbacks(
@@ -450,15 +453,15 @@ class App(_Callback):
         if self._p2w['HVOpVolt']['watcher'] is not None and \
                 self._p2w['HVOpVolt']['watcher'].is_alive():
             self._update_log('WARN:Interrupting HVPS voltage ramp...')
-            self._egun_dev.cmd_abort_rmp_hvps()
+            self.egun_dev.cmd_abort_rmp_hvps()
             self._p2w['HVOpVolt']['watcher'].join()
 
-        self._egun_dev.high_voltage_opvalue = value
+        self.egun_dev.high_voltage_opvalue = value
         self._hvopvolt = value
         self.run_callbacks('HVOpVolt-RB', self._hvopvolt)
 
         self._p2w['HVOpVolt']['watcher'] = _epics.ca.CAThread(
-            target=self._egun_dev.set_hv_voltage, daemon=True)
+            target=self.egun_dev.set_hv_voltage, daemon=True)
         self._p2w['HVOpVolt']['watcher'].start()
         self._p2w['HVOpVolt']['status'] = _Const.IdleRunning.Running
         self.run_callbacks(
@@ -784,7 +787,7 @@ class App(_Callback):
         cmd = 'on' if value else 'off'
         _t0 = _time.time()
         while _time.time() - _t0 < 10:
-            if self._egun_dev.trigps.is_on() == value:
+            if self.egun_dev.trigps.is_on() == value:
                 msg = 'Turned '+cmd+' EGun.'
                 break
             _time.sleep(0.1)
@@ -834,7 +837,7 @@ class App(_Callback):
             return
         if not self._evg_dev['InjectionEvt-Sel']:
             return
-        if not self._egun_dev.trigps.is_on():
+        if not self.egun_dev.trigps.is_on():
             return
         if cb_type == 'cb_val':
             if value is None or value < self._target_current:
@@ -856,9 +859,9 @@ class App(_Callback):
             self._update_log('ERR:Injection Auto Stop failed.')
 
     def _callback_update_type(self, **kws):
-        if self._egun_dev.is_single_bunch:
+        if self.egun_dev.is_single_bunch:
             self._type_mon = _Const.InjTypeMon.SingleBunch
-        elif self._egun_dev.is_multi_bunch:
+        elif self.egun_dev.is_multi_bunch:
             self._type_mon = _Const.InjTypeMon.MultiBunch
         else:
             self._type_mon = _Const.InjTypeMon.Undefined
@@ -974,7 +977,7 @@ class App(_Callback):
         else:
             self._update_log('ERR:Failed to turn off InjectionEvt.')
             self._update_log('Turning off EGun TriggerPS...')
-            if self._egun_dev.trigps.cmd_disable_trigger():
+            if self.egun_dev.trigps.cmd_disable_trigger():
                 msg = 'Turned off EGun TriggerPS.'
             else:
                 msg = 'ERR:Failed to turn off EGun TriggerPS.'
@@ -1062,6 +1065,8 @@ class App(_Callback):
                 # else, set PU voltage to 50%
                 self._prepare_topup('standby')
 
+        self._bias_feedback.do_update_models = True
+
         while self._mode == _Const.InjMode.TopUp:
             if not self._check_allok_2_inject():
                 break
@@ -1072,10 +1077,10 @@ class App(_Callback):
                 break
 
             self._update_log('Top-up period elapsed. Preparing...')
-            if not self._currinfo_dev.connected:
+            if not self.currinfo_dev.connected:
                 self._update_log('ERR:CurrInfo device disconnected.')
                 break
-            if self._currinfo_dev.current < self._target_current * 1.02:
+            if self.currinfo_dev.current < self._target_current * 1.02:
                 self._update_topupsts(_Const.TopUpSts.TurningOn)
                 self._update_log('Starting injection...')
                 if not self._start_injection():
@@ -1100,6 +1105,8 @@ class App(_Callback):
 
         self._prepare_topup('inject')
 
+        self._bias_feedback.do_update_models = False
+
         # update top-up status
         self._update_topupsts(_Const.TopUpSts.Off)
         self._update_log('Stopped top-up loop.')
@@ -1122,6 +1129,18 @@ class App(_Callback):
             if remaining <= _Const.PU_VOLTAGE_UP_TIME and \
                     not self._topup_pu_prepared:
                 self._prepare_topup('inject')
+
+            cond = remaining <= _Const.BIASFB_AHEADSETIME
+            cond &= bool(self._bias_feedback.loop_state)
+            cond &= not self._bias_feedback.already_set
+            if cond and self.currinfo_dev.connected:
+                dcur = self._bias_feedback.get_delta_current_per_pulse(
+                    per=self._topupperiod, nrpul=self._topupnrpulses,
+                    curr_avg=self._target_current,
+                    curr_now=self.currinfo_dev.current,
+                    ltime=self.currinfo_dev.lifetime)
+                bias = self._bias_feedback.get_bias_voltage(dcur)
+                self.egun_dev.bias.voltage = bias
 
             if _time.time() >= self._topupnext - self._topupheadstarttime:
                 return True
@@ -1309,21 +1328,21 @@ class App(_Callback):
                     self._evg_dev.bucketlist_sync != 1
                 value = _updt_bit(value, 1, val)
 
-            if self._egun_dev.connected:
+            if self.egun_dev.connected:
                 # EGBiasPS voltage diff. from desired
                 volt = self._sglbunbiasvolt \
                     if self._type == _Const.InjType.SingleBunch \
                     else self._multbunbiasvolt
-                val = abs(self._egun_dev.bias.voltage_mon - volt) > \
-                    self._egun_dev.bias_voltage_tol
+                val = abs(self.egun_dev.bias.voltage_mon - volt) > \
+                    self.egun_dev.bias_voltage_tol
                 value = _updt_bit(value, 2, val)
 
                 # EGFilaPS current diff. from nominal
-                val = not self._egun_dev.is_fila_on
+                val = not self.egun_dev.is_fila_on
                 value = _updt_bit(value, 3, val)
 
                 # EGHVPS voltage diff. from nominal
-                val = not self._egun_dev.is_hv_on
+                val = not self.egun_dev.is_hv_on
                 value = _updt_bit(value, 4, val)
 
                 # EGPulsePS setup is diff. from desired
@@ -1332,7 +1351,7 @@ class App(_Callback):
                 value = _updt_bit(value, 5, val)
 
                 # EGTriggerPS is off
-                val = not self._egun_dev.trigps.is_on()
+                val = not self.egun_dev.trigps.is_on()
                 value = _updt_bit(value, 6, val)
             else:
                 value = _updt_bit(value, 2, 1)

--- a/siriuspy/siriuspy/injctrl/main.py
+++ b/siriuspy/siriuspy/injctrl/main.py
@@ -1075,6 +1075,7 @@ class App(_Callback):
             self._update_log('Waiting for next injection...')
             if not self._wait_topup_period():
                 break
+            self._bias_feedback.already_set = False
 
             self._update_log('Top-up period elapsed. Preparing...')
             if not self.currinfo_dev.connected:
@@ -1129,6 +1130,7 @@ class App(_Callback):
             if remaining <= _Const.PU_VOLTAGE_UP_TIME and \
                     not self._topup_pu_prepared:
                 self._prepare_topup('inject')
+                continue
 
             cond = remaining <= _Const.BIASFB_AHEADSETIME
             cond &= bool(self._bias_feedback.loop_state)
@@ -1140,7 +1142,9 @@ class App(_Callback):
                     curr_now=self.currinfo_dev.current,
                     ltime=self.currinfo_dev.lifetime)
                 bias = self._bias_feedback.get_bias_voltage(dcur)
-                self.egun_dev.bias.voltage = bias
+                self.run_callbacks('MultBunBiasVolt-SP', bias)
+                self.set_multbunbiasvolt(bias)
+                self._bias_feedback.already_set = True
 
             if _time.time() >= self._topupnext - self._topupheadstarttime:
                 return True

--- a/siriuspy/siriuspy/injctrl/main.py
+++ b/siriuspy/siriuspy/injctrl/main.py
@@ -74,11 +74,7 @@ class App(_Callback):
         self._topup_pu_prepared = False
         self._abort = False
 
-        self._injsys_turn_on_count = 0
-        self._injsys_turn_off_count = 0
-
         self._rfkillbeam_mon = _Const.RFKillBeamMon.Idle
-        self._rfkillbeam_count = 0
 
         self._thread_autostop = None
 
@@ -304,12 +300,9 @@ class App(_Callback):
         self.run_callbacks('TopUpNextInj-Mon', self._topupnext)
         self.run_callbacks('TopUpNrPulses-SP', self._topupnrpulses)
         self.run_callbacks('TopUpNrPulses-RB', self._topupnrpulses)
-        self.run_callbacks('InjSysTurnOn-Cmd', self._injsys_turn_on_count)
-        self.run_callbacks('InjSysTurnOff-Cmd', self._injsys_turn_off_count)
         self.run_callbacks(
             'InjSysCmdDone-Mon', ','.join(self._injsys_dev.done))
         self.run_callbacks('InjSysCmdSts-Mon', _Const.InjSysCmdSts.Idle)
-        self.run_callbacks('RFKillBeam-Cmd', self._rfkillbeam_count)
         self.run_callbacks('RFKillBeam-Mon', _Const.RFKillBeamMon.Idle)
         self.run_callbacks('DiagStatusLI-Mon', self._status['LI'])
         self.run_callbacks('DiagStatusTB-Mon', self._status['TB'])
@@ -675,10 +668,7 @@ class App(_Callback):
         thr.start()
         if wait_finish:
             thr.join()
-
-        self._injsys_turn_on_count += 1
-        self.run_callbacks('InjSysTurnOn-Cmd', self._injsys_turn_on_count)
-        return False
+        return True
 
     def cmd_injsys_turn_off(self, value=None, wait_finish=False):
         """Set turn off Injection System."""
@@ -696,10 +686,7 @@ class App(_Callback):
         thr.start()
         if wait_finish:
             thr.join()
-
-        self._injsys_turn_off_count += 1
-        self.run_callbacks('InjSysTurnOff-Cmd', self._injsys_turn_off_count)
-        return False
+        return True
 
     def _watch_injsys(self, cmd, timeout=_Const.RF_RMP_TIMEOUT):
         self.run_callbacks(
@@ -759,10 +746,7 @@ class App(_Callback):
         self._rfkillbeam_mon = _Const.RFKillBeamMon.Kill
         self.run_callbacks('RFKillBeam-Mon', self._rfkillbeam_mon)
         _epics.ca.CAThread(target=self._watch_rfkillbeam, daemon=True).start()
-
-        self._rfkillbeam_count += 1
-        self.run_callbacks('RFKillBeam-Cmd', self._rfkillbeam_count)
-        return False
+        return True
 
     def _watch_rfkillbeam(self):
         ret = self._rfkillbeam.cmd_kill_beam()

--- a/siriuspy/siriuspy/injctrl/main.py
+++ b/siriuspy/siriuspy/injctrl/main.py
@@ -313,6 +313,7 @@ class App(_Callback):
         self.run_callbacks('DiagStatusSI-Mon', self._status['SI'])
         self.run_callbacks('DiagStatus-Mon', self._status['AS'])
         self.run_callbacks('InjStatus-Mon', self._injstatus)
+        self._bias_feedback.init_database()
         self.run_callbacks('Log-Mon', 'Started.')
 
     @property

--- a/siriuspy/siriuspy/injctrl/main.py
+++ b/siriuspy/siriuspy/injctrl/main.py
@@ -135,8 +135,6 @@ class App(_Callback):
                     n: _PV(n+':DiagStatus-Mon', connection_timeout=0.05)
                     for n in _RFDiagConst.ALL_DEVICES if n.startswith(sec)}
 
-        self._bias_feedback = _BiasFeedback(self)
-
         # auxiliary devices
         self.egun_dev = EGun(
             print_log=False, callback=self._update_dev_status)
@@ -232,6 +230,11 @@ class App(_Callback):
         else:
             self._hvopvolt = hvvolt
             self.egun_dev.high_voltage_opvalue = hvvolt
+
+        # Create object to make bias feedback:
+        self._bias_feedback = _BiasFeedback(self)
+        self._pvs_database.update(self._bias_feedback.database)
+        self.map_pv2write.update(self._bias_feedback.map_pv2write)
 
     def init_database(self):
         """Set initial PV values."""

--- a/siriuspy/tests/test_callbacks.py
+++ b/siriuspy/tests/test_callbacks.py
@@ -27,6 +27,7 @@ class TestCallbackClass(TestCase):
 
     public_interface = (
         'add_callback',
+        'has_callbacks',
         'remove_callback',
         'clear_callbacks',
         'run_callbacks',


### PR DESCRIPTION
This PR main feature is the addition of a Bias Feedback to the InjCtrl IOC for topup operation.
The logic of the feedback was inspired in the class added in lnls-fac/apsuite#201. 

Besides this addition, a few other classes were changed:
 - Callback: I added a property called `has_callbacks`.
 - CurrInfoSI: the InjCurr PV will always be updated when Current3GeV from the booster is updated.
 - CurrInfoSI, Lifetime and InjCtrl: the increment of the `-Cmd` was delegated to the Driver class of the IOC. See lnls-sirius/machine-applications#266