### PR TITLE
Fixes devices

### DIFF
--- a/siriuspy/siriuspy/devices/bpm.py
+++ b/siriuspy/siriuspy/devices/bpm.py
@@ -1011,7 +1011,7 @@ class FamBPMs(_Devices):
         Returns:
             int: code describing what happened:
                 =0: BPMs are ready.
-                >0: Index of the first BPM which did not updated plus 1.
+                >0: Index of the first BPM which did not update plus 1.
 
         """
         for bpm in self._devices:
@@ -1030,7 +1030,7 @@ class FamBPMs(_Devices):
         Returns:
             int: code describing what happened:
                 =0: BPMs are ready.
-                >0: Index of the first BPM which did not updated plus 1.
+                >0: Index of the first BPM which did not update plus 1.
 
         """
         for i, bpm in enumerate(self._devices):
@@ -1051,7 +1051,7 @@ class FamBPMs(_Devices):
         Returns:
             int: code describing what happened:
                 =0: BPMs are ready.
-                >0: Index of the first BPM which did not updated plus 1.
+                >0: Index of the first BPM which did not update plus 1.
 
         """
         for bpm in self._devices:
@@ -1069,7 +1069,7 @@ class FamBPMs(_Devices):
         Returns:
             int: code describing what happened:
                 =0: BPMs are ready.
-                >0: Index of the first BPM which did not updated plus 1.
+                >0: Index of the first BPM which did not update plus 1.
 
         """
         for i, bpm in enumerate(self._devices):
@@ -1120,7 +1120,7 @@ class FamBPMs(_Devices):
                 -2: TypeError ocurred (maybe because some of them are None);
                 -1: Orbits have different sizes;
                 =0: Orbit updated.
-                >0: Index of the first BPM which did not updated plus 1.
+                >0: Index of the first BPM which did not update plus 1.
 
         """
         orbs0, self._initial_orbs = self._initial_orbs, None
@@ -1169,7 +1169,7 @@ class FamBPMs(_Devices):
                 -2: TypeError ocurred (maybe because some of them are None);
                 -1: Orbits have different sizes;
                 =0: Orbit updated.
-                >0: Index of the first BPM which did not updated plus 1.
+                >0: Index of the first BPM which did not update plus 1.
 
         """
         t00 = _time.time()

--- a/siriuspy/siriuspy/devices/pwrsupply.py
+++ b/siriuspy/siriuspy/devices/pwrsupply.py
@@ -204,9 +204,9 @@ class _PSDev(_Device):
         self['PwrState-Sel'] = value
 
     def set_strength(self, value, tol=0.2, timeout=10, wait_mon=False):
-        """Set RF phase and wait until it gets there."""
+        """Set strength and wait until it gets there."""
         self.strength = value
-        pv2wait = self._strength_rb_propty if wait_mon \
+        pv2wait = self._strength_mon_propty if wait_mon \
             else self._strength_rb_propty
         return self._wait_float(pv2wait, value, abs_tol=tol, timeout=timeout)
 

--- a/siriuspy/siriuspy/devices/pwrsupply.py
+++ b/siriuspy/siriuspy/devices/pwrsupply.py
@@ -203,6 +203,13 @@ class _PSDev(_Device):
         """."""
         self['PwrState-Sel'] = value
 
+    def set_strength(self, value, tol=0.2, timeout=10, wait_mon=False):
+        """Set RF phase and wait until it gets there."""
+        self.strength = value
+        pv2wait = self._strength_rb_propty if wait_mon \
+            else self._strength_rb_propty
+        return self._wait_float(pv2wait, value, abs_tol=tol, timeout=timeout)
+
     def cmd_turn_on(self, timeout=_default_timeout):
         """."""
         self.pwrstate = self.PWRSTATE.On

--- a/siriuspy/siriuspy/devices/timing.py
+++ b/siriuspy/siriuspy/devices/timing.py
@@ -42,7 +42,7 @@ class EVG(_Device):
     @nrpulses.setter
     def nrpulses(self, value):
         """Set number of pulses to repeat Bucket List."""
-        self['RepeatBucketList-SP'] = bool(value)
+        self['RepeatBucketList-SP'] = value
 
     @property
     def bucketlist_len(self):


### PR DESCRIPTION
Features:
 - add method to `PowerSupply` device to set strength and wait for monitor/readback to get there;
 - Remove auto-monitor of array PVs in `FamBPMs`;
 - Improve method `get_sampling_frequency` and make it a regular object method instead of a `staticmethod`
 - Improve logic of checking whether triggered acquisition finished sucessfully. Now the flow of a triggered acquisition should be like this:

```python3
fambpms = FamBPMs()
need_sum = True

ret = fambpms.mturn_config_acquisition()  #use as input here the necessary configurations
if ret < 0:
    raise Exception(f'BPM {-ret-1:d} did not finish last acquisition.')
elif ret >0:
    raise Exception(f'BPM {ret-1:d} is not ready for acquisition.')
fambpms.mturn_update_initial_orbit(consider_sum=need_sum)

# Send timing trigger

ret = fambpms.mturn_wait_update(consider_sum=need_sum)
if ret != 0:
    raise Exception(f'There was a problem with acquisition. Error code {ret:d}')

orbx, orby, sum = fambpms.get_mturn_orbit(return_sum=need_sum)

```