### PR TITLE
Improve SOFB Performance

### DIFF
--- a/siriuspy/siriuspy/sofb/bpms.py
+++ b/siriuspy/siriuspy/sofb/bpms.py
@@ -24,14 +24,12 @@ class BPM(_BaseTimingConfig):
         self._name = name
         self._orb_conv_unit = self._csorb.ORBIT_CONVERSION_UNIT
         pvpref = LL_PREF + ('-' if LL_PREF else '') + self._name + ':'
-        opt = {'connection_timeout': TIMEOUT}
+        opt = {'connection_timeout': TIMEOUT, 'auto_monitor': False}
         self._poskx = _PV(pvpref + 'PosKx-RB', **opt)
         self._posky = _PV(pvpref + 'PosKy-RB', **opt)
         self._ksum = _PV(pvpref + 'PosKsum-RB', **opt)
         self._polyx = _PV(pvpref + 'GEN_PolyXArrayCoeff-RB', **opt)
         self._polyy = _PV(pvpref + 'GEN_PolyYArrayCoeff-RB', **opt)
-        opt['callback'] = self._set_needs_update
-        opt['auto_monitor'] = True
         self._arraya = _PV(pvpref + 'GEN_AArrayData', **opt)
         self._arrayb = _PV(pvpref + 'GEN_BArrayData', **opt)
         self._arrayc = _PV(pvpref + 'GEN_CArrayData', **opt)
@@ -39,8 +37,6 @@ class BPM(_BaseTimingConfig):
         self._arrayx = _PV(pvpref + 'GEN_XArrayData', **opt)
         self._arrayy = _PV(pvpref + 'GEN_YArrayData', **opt)
         self._arrays = _PV(pvpref + 'GEN_SUMArrayData', **opt)
-        opt.pop('callback')
-        opt.pop('auto_monitor')
         self._offsetx = _PV(pvpref + 'PosXOffset-RB', **opt)
         self._offsety = _PV(pvpref + 'PosYOffset-RB', **opt)
         self._config_ok_vals = {
@@ -144,6 +140,8 @@ class BPM(_BaseTimingConfig):
             'SUMPosCal': 'SUMPosCal-Sts'}
         self._config_pvs_rb = {
             k: _PV(pvpref + v, **opt) for k, v in pvs.items()}
+        self._config_pvs_rb['ACQStatus'].auto_monitor = True
+        self._config_pvs_rb['ACQStatus'].add_callback(self._set_needs_update)
 
     @property
     def name(self):

--- a/siriuspy/siriuspy/sofb/bpms.py
+++ b/siriuspy/siriuspy/sofb/bpms.py
@@ -15,11 +15,12 @@ TIMEOUT = 0.05
 
 class BPM(_BaseTimingConfig):
     """."""
+    MAX_UPT_CNT = 20  # equivalent of 10s of orbit update after Acq. PV update
 
     def __init__(self, name, callback=None):
         """."""
         super().__init__(name[:2], callback)
-        self.needs_update = True
+        self.needs_update_cnt = self.MAX_UPT_CNT
 
         self._name = name
         self._orb_conv_unit = self._csorb.ORBIT_CONVERSION_UNIT
@@ -141,7 +142,8 @@ class BPM(_BaseTimingConfig):
         self._config_pvs_rb = {
             k: _PV(pvpref + v, **opt) for k, v in pvs.items()}
         self._config_pvs_rb['ACQStatus'].auto_monitor = True
-        self._config_pvs_rb['ACQStatus'].add_callback(self._set_needs_update)
+        self._config_pvs_rb['ACQStatus'].add_callback(
+            self._reset_needs_update_cnt)
 
     @property
     def name(self):
@@ -740,9 +742,9 @@ class BPM(_BaseTimingConfig):
             th7*(pol[12] + ot2*pol[13]) +
             th9*pol[14])
 
-    def _set_needs_update(self, *args, **kwargs):
+    def _reset_needs_update_cnt(self, *args, **kwargs):
         _ = args, kwargs
-        self.needs_update = True
+        self.needs_update_cnt = self.MAX_UPT_CNT
 
 
 class TimingConfig(_BaseTimingConfig):

--- a/siriuspy/siriuspy/sofb/orbit.py
+++ b/siriuspy/siriuspy/sofb/orbit.py
@@ -836,8 +836,8 @@ class EpicsOrbit(BaseOrbit):
             nr_pts = self._smooth_npts
             do_update = False
             for i, bpm in enumerate(self.bpms):
-                if not leng or bpm.needs_update:
-                    bpm.needs_update = False
+                if not leng or bpm.needs_update_cnt > 0:
+                    bpm.needs_update_cnt -= 1
                     do_update = True
                     posx = self._get_pos(
                         bpm.mtposx, self.ref_orbs['X'][i], samp)
@@ -912,8 +912,8 @@ class EpicsOrbit(BaseOrbit):
             nr_pts = self._smooth_npts
             do_update = False
             for i, bpm in enumerate(self.bpms):
-                if not leng or bpm.needs_update:
-                    bpm.needs_update = False
+                if not leng or bpm.needs_update_cnt > 0:
+                    bpm.needs_update_cnt -= 1
                     do_update = True
                     dic.update({
                         'refx': self.ref_orbs['X'][i],


### PR DESCRIPTION
In PR #907, an improvement of SOFB Performance on TB, BO and TS during Idle time was made.
This improvement relied on only updating the trajectory PVs when there was news from BPMs.
However, it accomplished this by monitoring the arrays PVs, which proved to deteriorate the performance when a stream of acquisitions were being carried out.

This PR fixes this by turning on the monitoring of the acquisition status PV instead.
