### PR TITLE
Upgrade SOFB

### DIFF
--- a/siriuspy/siriuspy/epics/__init__.py
+++ b/siriuspy/siriuspy/epics/__init__.py
@@ -8,8 +8,10 @@ from .pv import PV
 from .pv_time_serie import *
 from .properties import *
 from .multiproc import CAProcessSpawn
+from .threading import CAThread
 
 del pv
 del pv_time_serie
 del properties
 del multiproc
+del threading

--- a/siriuspy/siriuspy/epics/threading.py
+++ b/siriuspy/siriuspy/epics/threading.py
@@ -1,0 +1,7 @@
+"""Sirius CAThread class."""
+import epics
+
+
+class CAThread(epics.ca.CAThread):
+    """."""
+    pass

--- a/siriuspy/siriuspy/sofb/base_class.py
+++ b/siriuspy/siriuspy/sofb/base_class.py
@@ -1,6 +1,7 @@
 """Definition module."""
 import math as _math
 import logging as _log
+
 import numpy as _np
 
 from ..callbacks import Callback as _Callback

--- a/siriuspy/siriuspy/sofb/bpms.py
+++ b/siriuspy/siriuspy/sofb/bpms.py
@@ -1,5 +1,6 @@
 """Module to deal with orbit acquisition."""
 import logging as _log
+
 import numpy as _np
 
 from ..epics import PV as _PV

--- a/siriuspy/siriuspy/sofb/correctors.py
+++ b/siriuspy/siriuspy/sofb/correctors.py
@@ -8,7 +8,7 @@ import numpy as _np
 from PRUserial485 import EthBridgeClient
 
 from .. import util as _util
-from ..epics import PV as _PV
+from ..epics import PV as _PV, CAThread as _Thread
 from ..thread import RepeaterThread as _Repeat
 from ..pwrsupply.csdev import Const as _PSConst
 from ..pwrsupply.bsmp.constants import ConstPSBSMP as _ConstPSBSMP
@@ -16,9 +16,7 @@ from ..timesys.csdev import Const as _TIConst
 from ..search import HLTimeSearch as _HLTimesearch
 from ..envars import VACA_PREFIX as LL_PREF
 from ..namesys import SiriusPVName as _PVName
-
 from ..pwrsupply.pssofb import PSSOFB as _PSSOFB
-
 
 from .base_class import BaseClass as _BaseClass, \
     BaseTimingConfig as _BaseTimingConfig, compare_kicks as _compare_kicks
@@ -677,8 +675,15 @@ class EpicsCorrectors(BaseCorrectors):
             self._update_log('ERR: ' + str(err))
             _log.error(_traceback.format_exc())
 
-    def set_corrs_mode(self, value):
+    def set_corrs_mode(self, value, is_thread=False):
         """Set mode of CHs and CVs method. Only called when acc==SI."""
+        if not is_thread:
+            _Thread(
+                self.set_corrs_mode,
+                args=(value, ), kwargs={'is_thread': True},
+                daemon=True).start()
+            return True
+
         if value not in self._csorb.CorrSync:
             return False
         self.sync_kicks = value
@@ -757,8 +762,15 @@ class EpicsCorrectors(BaseCorrectors):
         self.run_callbacks('CorrPSSOFBEnbl-Mon', val)
         return True
 
-    def configure_correctors(self, _):
+    def configure_correctors(self, val, is_thread=False):
         """Configure correctors method."""
+        if not is_thread:
+            _Thread(
+                self.configure_correctors,
+                args=(val, ), kwargs={'is_thread': True},
+                daemon=True).start()
+            return True
+
         corrs = self._get_used_corrs(include_rf=True)
         for corr in corrs:
             if not corr.connected:
@@ -773,14 +785,12 @@ class EpicsCorrectors(BaseCorrectors):
                 continue
             corr.configure()
         if not self.isring:
-            return True
-
+            return
         if self.acc == 'SI' and self.sync_kicks != self._csorb.CorrSync.Off:
             if not self.timing.configure():
                 msg = 'ERR: Failed to configure timing'
                 self._update_log(msg)
                 _log.error(msg[5:])
-        return True
 
     def _update_status(self):
         status = 0b0000111

--- a/siriuspy/siriuspy/sofb/main.py
+++ b/siriuspy/siriuspy/sofb/main.py
@@ -3,10 +3,10 @@
 from time import time as _time, sleep as _sleep
 import logging as _log
 from functools import partial as _part
-from threading import Thread as _Thread
+
 import numpy as _np
 
-from ..epics import PV as _PV
+from ..epics import PV as _PV, CAThread as _Thread
 from ..devices import HLFOFB
 
 from .matrix import BaseMatrix as _BaseMatrix

--- a/siriuspy/siriuspy/sofb/matrix.py
+++ b/siriuspy/siriuspy/sofb/matrix.py
@@ -1,13 +1,12 @@
 """Class of the Response Matrix."""
 
 import os as _os
-from copy import deepcopy as _dcopy
 import logging as _log
 from functools import partial as _part
-from threading import Thread as _Thread
 
 import numpy as _np
 
+from ..epics import PV as _PV, CAThread as _Thread
 from .base_class import BaseClass as _BaseClass
 
 
@@ -86,40 +85,63 @@ class EpicsMatrix(BaseMatrix):
             dbase['RFEnbl-Sel'] = _part(self.set_enbllist, 'rf')
         return dbase
 
-    def set_respmat_mode(self, mode):
+    def set_respmat_mode(self, mode, is_thread=False):
         """Set the response matrix mode."""
+        if not is_thread:
+            _Thread(
+                self.set_respmat_mode,
+                args=(mode, ), kwargs={'is_thread': True},
+                daemon=True).start()
+            return True
+
         msg = 'Setting New RespMatMode.'
         self._update_log(msg)
         _log.info(msg)
         if mode not in self._csorb.RespMatMode:
-            return False
+            self.run_callbacks('RespMatMode-Sel', self._respmat_mode)
+            return
         old_ = self._respmat_mode
         self._respmat_mode = mode
         if not self._calc_matrices():
             self._respmat_mode = old_
-            return False
-        self.run_callbacks('RespMatMode-Sts', mode)
-        return True
+            self.run_callbacks('RespMatMode-Sel', self._respmat_mode)
+            return
+        self.run_callbacks('RespMatMode-Sts', self._respmat_mode)
 
-    def set_respmat(self, mat):
+    def set_respmat(self, mat, is_thread=False):
         """Set the response matrix in memory and save it in file."""
+        if not is_thread:
+            _Thread(
+                self.set_respmat,
+                args=(mat, ), kwargs={'is_thread': True},
+                daemon=True).start()
+            return True
+
         msg = 'Setting New RespMat.'
         self._update_log(msg)
         _log.info(msg)
         if mat is None:
-            return False
+            self.run_callbacks('RespMat-SP', list(self.respmat.ravel()))
+            return
         mat = _np.reshape(mat, [-1, self._csorb.nr_corrs])
         old_ = self.respmat.copy()
         self.respmat = mat
         if not self._calc_matrices():
             self.respmat = old_
-            return False
+            self.run_callbacks('RespMat-SP', list(self.respmat.ravel()))
+            return
         self._save_respmat(mat)
         self.run_callbacks('RespMat-RB', list(self.respmat.ravel()))
-        return True
 
-    def set_enbllist(self, key, val):
+    def set_enbllist(self, key, val, is_thread=False):
         """."""
+        if not is_thread:
+            _Thread(
+                self.set_enbllist,
+                args=(key, val), kwargs={'is_thread': True},
+                daemon=True).start()
+            return True
+
         msg = 'Setting {0:s} EnblList'.format(key.upper())
         self._update_log(msg)
         _log.info(msg)
@@ -136,14 +158,14 @@ class EpicsMatrix(BaseMatrix):
             new_ = new2_
         self.select_items[key] = new_
 
+        pvn = self.selection_pv_names[key]
         if not self._calc_matrices():
             self.select_items[key] = bkup
-            return False
-        if new_.size == 1:  # Deal with RF
-            self.run_callbacks(self.selection_pv_names[key], bool(new_))
-        else:
-            self.run_callbacks(self.selection_pv_names[key], new_)
-        return True
+            new_ = bkup
+            pvn = pvn.replace('-RB', '-SP')
+
+        new_ = bool(new_) if new_.size == 1 else new_
+        self.run_callbacks(pvn, new_)
 
     def calc_kicks(self, orbit):
         """Calculate the kick from the orbit distortion given."""
@@ -185,25 +207,39 @@ class EpicsMatrix(BaseMatrix):
         if self.isring:
             self.run_callbacks('DeltaKickRF-Mon', kicks[-1])
 
-    def set_min_sing_value(self, num):
+    def set_min_sing_value(self, num, is_thread=False):
         """."""
+        if not is_thread:
+            _Thread(
+                self.set_min_sing_value,
+                args=(num, ), kwargs={'is_thread': True},
+                daemon=True).start()
+            return True
+
         bkup = self.min_sing_val
         self.min_sing_val = float(num)
         if not self._calc_matrices():
             self.min_sing_val = bkup
-            return False
+            self.run_callbacks('MinSingValue-SP', self.min_sing_val)
+            return
         self.run_callbacks('MinSingValue-RB', self.min_sing_val)
-        return True
 
-    def set_tikhonov_reg_const(self, num):
+    def set_tikhonov_reg_const(self, num, is_thread=False):
         """."""
+        if not is_thread:
+            _Thread(
+                self.set_tikhonov_reg_const,
+                args=(num, ), kwargs={'is_thread': True},
+                daemon=True).start()
+            return True
+
         bkup = self.tikhonov_reg_const
         self.tikhonov_reg_const = float(num)
         if not self._calc_matrices():
             self.tikhonov_reg_const = bkup
-            return False
+            self.run_callbacks('TikhonovRegConst-SP', self.tikhonov_reg_const)
+            return
         self.run_callbacks('TikhonovRegConst-RB', self.tikhonov_reg_const)
-        return True
 
     def _calc_matrices(self):
         msg = 'Calculating Inverse Matrix.'
@@ -295,7 +331,7 @@ class EpicsMatrix(BaseMatrix):
         filename = self._csorb.respmat_fname
         boo = False
         if _os.path.isfile(filename):
-            boo = self.set_respmat(_np.loadtxt(filename))
+            boo = self.set_respmat(_np.loadtxt(filename), is_thread=True)
             if boo:
                 msg = 'Loading RespMat from file.'
             else:


### PR DESCRIPTION
This PR:
 - Creates a class `CAThread` derived from `pyepics.ca.CAThread` to be used in threading when PVs handling is needed;
 - Starts using this class in SOFB;
 - Changes all SOFB setpoint methods which require some calculation or validation so that they return as fast as they can, leaving the hard work to threads.