### PR TITLE
Improve Normalizer

### DIFF
--- a/siriuspy/siriuspy/magnet/factory.py
+++ b/siriuspy/siriuspy/magnet/factory.py
@@ -15,19 +15,25 @@ class NormalizerFactory:
     """Factory class for normalizer objects."""
 
     @staticmethod
-    def create(maname):
+    def create(maname, **kwargs):
         """Return appropriate normalizer."""
         psname = _MASearch.conv_maname_2_psnames(maname)[0]
         magfunc = _PSSearch.conv_psname_2_magfunc(psname)
         ma_class = _mutil.magnet_class(maname)
         if ma_class == 'dipole':
-            return _norm.DipoleNormalizer(maname, magnet_conv_sign=-1.0)
+            kwargs['magnet_conv_sign'] = -1.0
+            return _norm.DipoleNormalizer(maname, **kwargs)
         if ma_class == 'trim':
-            return _norm.TrimNormalizer(maname, magnet_conv_sign=-1.0)
+            kwargs['magnet_conv_sign'] = -1.0
+            return _norm.TrimNormalizer(maname, **kwargs)
         if ma_class == 'id-apu':
-            return _norm.APUNormalizer(maname, magnet_conv_sign=+1.0)
+            kwargs['magnet_conv_sign'] = +1.0
+            return _norm.APUNormalizer(maname, **kwargs)
         if magfunc == 'corrector-horizontal':
-            return _norm.MagnetNormalizer(maname, magnet_conv_sign=+1.0)
+            kwargs['magnet_conv_sign'] = +1.0
+            return _norm.MagnetNormalizer(maname, **kwargs)
         if 'TB' in maname and 'QD' in maname:
-            return _norm.MagnetNormalizer(maname, magnet_conv_sign=+1.0,)
-        return _norm.MagnetNormalizer(maname, magnet_conv_sign=-1.0)
+            kwargs['magnet_conv_sign'] = +1.0
+            return _norm.MagnetNormalizer(maname, **kwargs)
+        kwargs['magnet_conv_sign'] = -1.0
+        return _norm.MagnetNormalizer(maname, **kwargs)

--- a/siriuspy/siriuspy/magnet/normalizer.py
+++ b/siriuspy/siriuspy/magnet/normalizer.py
@@ -20,8 +20,6 @@ if not _BETA_APPROXIMATION:
     _GAMMA_2_GEV = _mp.constants.electron_rest_energy * _mp.units.joule_2_GeV
 
 _MAGFUNCS = _mutil.get_magfunc_2_multipole_dict()
-_IS_DIPOLE = _re.compile(".*:[A-Z]{2}-B.*:.+$")
-_IS_FAM = _re.compile(".*[A-Z]{2}-Fam:[A-Z]{2}-.+$")
 _KCOEFF = _mp.constants.elementary_charge / \
           _mp.constants.light_speed / \
           _mp.constants.electron_mass / \

--- a/siriuspy/siriuspy/magnet/normalizer.py
+++ b/siriuspy/siriuspy/magnet/normalizer.py
@@ -355,8 +355,7 @@ class TrimNormalizer(_MagnetNormalizer):
 
     TYPE = 'TrimNormalizer'
 
-    def __init__(self, maname, magnet_conv_sign=-1.0,
-                 **kwargs):
+    def __init__(self, maname, **kwargs):
         """Call super and initializes a dipole and the family magnet."""
         super(TrimNormalizer, self).__init__(maname, **kwargs)
 

--- a/siriuspy/siriuspy/magnet/normalizer.py
+++ b/siriuspy/siriuspy/magnet/normalizer.py
@@ -32,6 +32,8 @@ class _MagnetNormalizer:
     def __init__(
             self, maname, magnet_conv_sign=-1, default_strengths_dipole=None):
         """Class constructor."""
+        self._default_strengths_dipole = None
+        self._brho = None
         self.default_strengths_dipole = default_strengths_dipole  # [GeV]
         self._maname = _SiriusPVName(maname) if type(maname) == str else maname
         self._psnames = _MASearch.conv_maname_2_psnames(self._maname)
@@ -43,6 +45,16 @@ class _MagnetNormalizer:
         self._mfmult = _MAGFUNCS[self._magfunc]
         self._psname = self._power_supplies()[0]
         self._calc_conv_coef()
+
+    @property
+    def default_strengths_dipole(self):
+        return self._default_strengths_dipole
+
+    @default_strengths_dipole.setter
+    def default_strengths_dipole(self, value):
+        self._default_strengths_dipole = value
+        if value is not None:
+            self._brho = self._get_brho(value)
 
     @property
     def magfunc(self):
@@ -86,9 +98,9 @@ class _MagnetNormalizer:
     def _get_brho(self, strengths_dipole=None, **kwargs):
         """Calculate appropriate brho."""
         _ = kwargs
-        if strengths_dipole is None:
-            strengths_dipole = self.default_strengths_dipole
-        if strengths_dipole is None:
+        if strengths_dipole is None and self._brho is not None:
+            return self._brho
+        elif strengths_dipole is None:
             raise ValueError(
                 "Missing input 'strengths_dipole' and no default value is "
                 "set in attribute 'default_strengths_dipole'.")


### PR DESCRIPTION
 - Fix bug in initializer of TrimNormalizer.
 - Add optional attribute called `default_strengths_dipole` to normalizer classes to avoid having to define `strengths_dipole` on every conversion call.
 - Remove unused hiden module constants.