### PR TITLE
Adapt classes and devices to new FOFB controllers IOC version

### DIFF
--- a/siriuspy/siriuspy/clientconfigdb/types/as_diagnostics.py
+++ b/siriuspy/siriuspy/clientconfigdb/types/as_diagnostics.py
@@ -1413,6 +1413,68 @@ _tune_pvs = [
     ['SI-Glob:DI-TuneProc-V:FiltType-Sel', 0, 0],
     ]
 
+_fofbctrls = [
+    'IA-01RaBPM:BS-FOFBCtrl',
+    'IA-02RaBPM:BS-FOFBCtrl',
+    'IA-03RaBPM:BS-FOFBCtrl',
+    'IA-04RaBPM:BS-FOFBCtrl',
+    'IA-05RaBPM:BS-FOFBCtrl',
+    'IA-06RaBPM:BS-FOFBCtrl',
+    'IA-07RaBPM:BS-FOFBCtrl',
+    'IA-08RaBPM:BS-FOFBCtrl',
+    'IA-09RaBPM:BS-FOFBCtrl',
+    'IA-10RaBPM:BS-FOFBCtrl',
+    'IA-11RaBPM:BS-FOFBCtrl',
+    'IA-12RaBPM:BS-FOFBCtrl',
+    'IA-13RaBPM:BS-FOFBCtrl',
+    'IA-14RaBPM:BS-FOFBCtrl',
+    'IA-15RaBPM:BS-FOFBCtrl',
+    'IA-16RaBPM:BS-FOFBCtrl',
+    'IA-17RaBPM:BS-FOFBCtrl',
+    'IA-18RaBPM:BS-FOFBCtrl',
+    'IA-19RaBPM:BS-FOFBCtrl',
+    'IA-20RaBPM:BS-FOFBCtrl',
+]
+_fofb_propts = [
+    [':TRIGGER0Dir-Sel', 1, 0.0],
+    [':TRIGGER0DirPol-Sel', 1, 0.0],
+    [':TRIGGER0RcvLen-SP', 1, 0.0],
+    [':TRIGGER0TrnLen-SP', 1, 0.0],
+    [':TRIGGER1Dir-Sel', 1, 0.0],
+    [':TRIGGER1DirPol-Sel', 1, 0.0],
+    [':TRIGGER1RcvLen-SP', 1, 0.0],
+    [':TRIGGER1TrnLen-SP', 1, 0.0],
+    [':TRIGGER2Dir-Sel', 0, 0.0],
+    [':TRIGGER2DirPol-Sel', 1, 0.0],
+    [':TRIGGER2RcvLen-SP', 1, 0.0],
+    [':TRIGGER2TrnLen-SP', 1, 0.0],
+    [':TRIGGER3Dir-Sel', 0, 0.0],
+    [':TRIGGER3DirPol-Sel', 1, 0.0],
+    [':TRIGGER3RcvLen-SP', 1, 0.0],
+    [':TRIGGER3TrnLen-SP', 1, 0.0],
+    [':TRIGGER4Dir-Sel', 1, 0.0],
+    [':TRIGGER4DirPol-Sel', 1, 0.0],
+    [':TRIGGER4RcvLen-SP', 1, 0.0],
+    [':TRIGGER4TrnLen-SP', 1, 0.0],
+    [':TRIGGER5Dir-Sel', 1, 0.0],
+    [':TRIGGER5DirPol-Sel', 1, 0.0],
+    [':TRIGGER5RcvLen-SP', 1, 0.0],
+    [':TRIGGER5TrnLen-SP', 1, 0.0],
+    [':TRIGGER6Dir-Sel', 1, 0.0],
+    [':TRIGGER6DirPol-Sel', 1, 0.0],
+    [':TRIGGER6RcvLen-SP', 1, 0.0],
+    [':TRIGGER6TrnLen-SP', 1, 0.0],
+    [':TRIGGER7Dir-Sel', 1, 0.0],
+    [':TRIGGER7DirPol-Sel', 1, 0.0],
+    [':TRIGGER7RcvLen-SP', 1, 0.0],
+    [':TRIGGER7TrnLen-SP', 1, 0.0],
+    ]
+_fofb_pvs = list()
+for dev in _fofbctrls:
+    for ppt, val, dly in _fofb_propts:
+        _fofb_pvs.append([dev+ppt, val, dly])
+
+
 # When using this type of configuration to set the machine,
 # the list of PVs should be processed in the same order they are stored
 # in the configuration. The second numeric parameter in the pair is the
@@ -1421,6 +1483,6 @@ _tune_pvs = [
 _template_dict = {
     'pvs':
         _li_diags + _amcfpgaevr_pvs + _bpm_pvs + _scrn_pvs + _vlightcam_pvs +
-        _dcct_pvs + _slit_pvs + _tune_pvs
+        _dcct_pvs + _slit_pvs + _tune_pvs + _fofb_pvs
         # + _ict_pvs  # commented out becaus IOC is down.
         }

--- a/siriuspy/siriuspy/devices/device.py
+++ b/siriuspy/siriuspy/devices/device.py
@@ -379,6 +379,7 @@ class Devices:
             comp = getattr(_opr, comp)
         dev2val = self._get_dev_2_val(devices, values)
 
+        tini = _time.time()
         for _ in range(int(timeout/_TINY_INTERVAL)):
             okdevs = set()
             for k, v in dev2val.items():
@@ -387,14 +388,18 @@ class Devices:
                     boo = _np.all(boo)
                 if boo:
                     okdevs.add(k)
+                if _time.time() - tini > timeout:
+                    break
             list(map(dev2val.__delitem__, okdevs))
             if not dev2val:
+                break
+            if _time.time() - tini > timeout:
                 break
             _time.sleep(_TINY_INTERVAL)
 
         allok = not dev2val
         if return_prob:
-            return allok, [dev.devname+':'+propty for dev in dev2val]
+            return allok, [dev.pv_object(propty).pvname for dev in dev2val]
         return allok
 
     def _get_dev_2_val(self, devices, values):

--- a/siriuspy/siriuspy/devices/fofb.py
+++ b/siriuspy/siriuspy/devices/fofb.py
@@ -65,13 +65,13 @@ class FOFBCtrlRef(_Device, _FOFBCtrlBase):
         self['RefOrbY-SP'] = _np.array(value, dtype=int)
 
     def check_refx(self, value):
-        """Check whether first half of RefOrb is equal to value."""
+        """Check whether RefOrbX is equal to value."""
         if not _np.all(self.refx == value):
             return False
         return True
 
     def check_refy(self, value):
-        """Check whether second half of RefOrb is equal to value."""
+        """Check whether RefOrbY is equal to value."""
         if not _np.all(self.refy == value):
             return False
         return True

--- a/siriuspy/siriuspy/devices/fofb.py
+++ b/siriuspy/siriuspy/devices/fofb.py
@@ -869,10 +869,13 @@ class FamFastCorrs(_Devices):
         if not isinstance(values, (list, tuple, _np.ndarray)):
             raise ValueError('Value must be iterable.')
         devs = self._get_devices(psnames, psindices)
+        if not len(values) == len(devs):
+            raise ValueError('Values and indices must have the same size.')
         if any([len(v) != 2*NR_BPM for v in values]):
             raise ValueError(f'Value must have size {2*NR_BPM}.')
         for i, dev in enumerate(devs):
-            dev.invrespmat_row = values[i]
+            dev.invrespmat_row_x = values[i][:NR_BPM]
+            dev.invrespmat_row_y = values[i][NR_BPM:]
         return True
 
     def check_invrespmat_row(
@@ -887,7 +890,9 @@ class FamFastCorrs(_Devices):
         devs = self._get_devices(psnames, psindices)
         if not values.shape[0] == len(devs):
             raise ValueError('Values and indices must have the same size.')
-        impltd = _np.asarray([d.invrespmat_row for d in devs])
+        impltd = _np.asarray([
+            _np.hstack([d.invrespmat_row_x, d.invrespmat_row_y])
+            for d in devs])
         if _np.allclose(values, impltd, atol=atol):
             return True
         return False

--- a/siriuspy/siriuspy/devices/fofb.py
+++ b/siriuspy/siriuspy/devices/fofb.py
@@ -541,18 +541,18 @@ class FamFOFBControllers(_Devices):
 
         # temporary solution: disable BPM DCCs that are not in FOFB network
         dcc2dsbl = list(self._bpmdcc2dsbl.values())
-        self._set_devices_propty(dcc2dsbl, 'CCEnable-SP', 0)
+        self._set_devices_propty(dcc2dsbl, 'CCEnable-Sel', 0)
         if not self._wait_devices_propty(
-                dcc2dsbl, 'CCEnable-RB', 0, timeout=timeout/2):
+                dcc2dsbl, 'CCEnable-Sts', 0, timeout=timeout/2):
             return False
 
-        self._set_devices_propty(alldccs, 'CCEnable-SP', 0)
+        self._set_devices_propty(alldccs, 'CCEnable-Sel', 0)
         if not self._wait_devices_propty(
-                alldccs, 'CCEnable-RB', 0, timeout=timeout/2):
+                alldccs, 'CCEnable-Sts', 0, timeout=timeout/2):
             return False
-        self._set_devices_propty(enbdccs, 'CCEnable-SP', 1)
+        self._set_devices_propty(enbdccs, 'CCEnable-Sel', 1)
         if not self._wait_devices_propty(
-                enbdccs, 'CCEnable-RB', 1, timeout=timeout/2):
+                enbdccs, 'CCEnable-Sts', 1, timeout=timeout/2):
             return False
         self._evt_fofb.cmd_external_trigger()
         return True

--- a/siriuspy/siriuspy/devices/fofb.py
+++ b/siriuspy/siriuspy/devices/fofb.py
@@ -886,16 +886,14 @@ class FamFastCorrs(_Devices):
             return False
         if not isinstance(values, (list, tuple, _np.ndarray)):
             raise ValueError('Value must be iterable.')
-        values = _np.asarray(values)
         devs = self._get_devices(psnames, psindices)
-        if not values.shape[0] == len(devs):
+        if not len(values) == len(devs):
             raise ValueError('Values and indices must have the same size.')
-        impltd = _np.asarray([
-            _np.hstack([d.invrespmat_row_x, d.invrespmat_row_y])
-            for d in devs])
-        if _np.allclose(values, impltd, atol=atol):
-            return True
-        return False
+        for i, dev in enumerate(devs):
+            impltd = _np.hstack([dev.invrespmat_row_x, dev.invrespmat_row_y])
+            if not _np.allclose(values[i], impltd, atol=atol):
+                return False
+        return True
 
     def set_fofbacc_gain(self, values, psnames=None, psindices=None):
         """Command to set power supply correction gain."""

--- a/siriuspy/siriuspy/devices/pwrsupply.py
+++ b/siriuspy/siriuspy/devices/pwrsupply.py
@@ -49,7 +49,8 @@ class _PSDev(_Device):
         'TestWavePeriod-RB', 'TestWavePeriod-SP',
         'Voltage-RB', 'Voltage-SP', 'Voltage-Mon',
         'VoltGain-RB', 'VoltGain-SP', 'VoltOffset-RB', 'VoltOffset-SP',
-        'InvRespMatRow-SP', 'InvRespMatRow-RB',
+        'InvRespMatRowX-SP', 'InvRespMatRowX-RB',
+        'InvRespMatRowY-SP', 'InvRespMatRowY-RB',
         'FOFBAccGain-SP', 'FOFBAccGain-RB',
         'FOFBAccFreeze-Sel', 'FOFBAccFreeze-Sts',
         'FOFBAccClear-Cmd',
@@ -910,13 +911,22 @@ class PowerSupplyFC(_PSDev):
         return self._wait('OpMode-Sts', mode, timeout=timeout)
 
     @property
-    def invrespmat_row(self):
-        """Correction coefficient value."""
-        return self['InvRespMatRow-RB']
+    def invrespmat_row_x(self):
+        """Horizontal correction coefficient value."""
+        return self['InvRespMatRowX-RB']
 
-    @invrespmat_row.setter
-    def invrespmat_row(self, value):
-        self['InvRespMatRow-SP'] = _np.array(value, dtype=float)
+    @invrespmat_row_x.setter
+    def invrespmat_row_x(self, value):
+        self['InvRespMatRowX-SP'] = _np.array(value, dtype=float)
+
+    @property
+    def invrespmat_row_y(self):
+        """Vertical correction coefficient value."""
+        return self['InvRespMatRowY-RB']
+
+    @invrespmat_row_y.setter
+    def invrespmat_row_y(self, value):
+        self['InvRespMatRowY-SP'] = _np.array(value, dtype=float)
 
     @property
     def fofbacc_gain(self):

--- a/siriuspy/siriuspy/fofb/main.py
+++ b/siriuspy/siriuspy/fofb/main.py
@@ -878,10 +878,11 @@ class App(_Callback):
         if not self._check_fofbctrl_connection():
             return False
         self._update_log('Checking...')
-        reforb = _np.hstack([self._reforbhw_x, self._reforbhw_y])
-        if not self._llfofb_dev.check_reforb(reforb):
+        if not self._llfofb_dev.check_reforbx(self._reforbhw_x) or not \
+                self._llfofb_dev.check_reforby(self._reforbhw_y):
             self._update_log('Syncing FOFB RefOrb...')
-            self._llfofb_dev.set_reforb(reforb)
+            self._llfofb_dev.set_reforbx(self._reforbhw_x)
+            self._llfofb_dev.set_reforby(self._reforbhw_y)
             self._update_log('...done!')
         else:
             self._update_log('FOFB RefOrb already synced.')
@@ -1077,6 +1078,9 @@ class App(_Callback):
         refhw = _np.round(refhw)  # round, low level expect it to be int
         refhw = _np.roll(refhw, 1)  # make BPM 01M1 the first element
         setattr(self, '_reforbhw_' + plane.lower(), refhw)
+
+        # set reforb to FOFB controllers
+        setattr(self._llfofb_dev, 'set_reforb' + plane.lower(), refhw)
 
         # update readback PV
         self.run_callbacks(f'RefOrb{plane.upper()}-RB', list(ref.ravel()))
@@ -1902,8 +1906,8 @@ class App(_Callback):
                 if not self._llfofb_dev.linkpartners_connected:
                     value = _updt_bit(value, 3, 1)
                 # RefOrbSynced
-                reforb = _np.hstack([self._reforbhw_x, self._reforbhw_y])
-                if not self._llfofb_dev.check_reforb(reforb):
+                if not self._llfofb_dev.check_reforbx(self._reforbhw_x) or not\
+                        self._llfofb_dev.check_reforby(self._reforbhw_y):
                     value = _updt_bit(value, 4, 1)
                 # TimeFrameLenSynced
                 tframelen = self._time_frame_len

--- a/siriuspy/siriuspy/fofb/main.py
+++ b/siriuspy/siriuspy/fofb/main.py
@@ -127,7 +127,9 @@ class App(_Callback):
             pvo = pso.pv_object('CurrentRef-Mon')
             pvo.auto_monitor = True
             self._kick_buffer.append([])
-            pvo.add_callback(_part(self._update_kick_buffer, ps_index=idx))
+            pvo.add_callback(
+                _part(self._update_kick_buffer, ps_index=idx),
+                with_ctrlvars=False)
 
         self._rf_dev = _RFGen()
 
@@ -139,7 +141,8 @@ class App(_Callback):
             pvo = dev.pv_object('LoopIntlk-Mon')
             self._intlk_values[pvo.pvname] = 0
             pvo.auto_monitor = True
-            pvo.add_callback(self._callback_loopintlk)
+            pvo.add_callback(
+                self._callback_loopintlk, with_ctrlvars=False)
             self._intlk_pvs.append(pvo)
 
         self._corrs_dev.wait_for_connection(self._const.DEF_TIMEWAIT)

--- a/siriuspy/siriuspy/fofb/main.py
+++ b/siriuspy/siriuspy/fofb/main.py
@@ -128,8 +128,7 @@ class App(_Callback):
             pvo.auto_monitor = True
             self._kick_buffer.append([])
             pvo.add_callback(
-                _part(self._update_kick_buffer, ps_index=idx),
-                with_ctrlvars=False)
+                _part(self._update_kick_buffer, ps_index=idx))
 
         self._rf_dev = _RFGen()
 
@@ -141,8 +140,7 @@ class App(_Callback):
             pvo = dev.pv_object('LoopIntlk-Mon')
             self._intlk_values[pvo.pvname] = 0
             pvo.auto_monitor = True
-            pvo.add_callback(
-                self._callback_loopintlk, with_ctrlvars=False)
+            pvo.add_callback(self._callback_loopintlk)
             self._intlk_pvs.append(pvo)
 
         self._corrs_dev.wait_for_connection(self._const.DEF_TIMEWAIT)

--- a/siriuspy/siriuspy/fofb/main.py
+++ b/siriuspy/siriuspy/fofb/main.py
@@ -1083,7 +1083,8 @@ class App(_Callback):
         setattr(self, '_reforbhw_' + plane.lower(), refhw)
 
         # set reforb to FOFB controllers
-        setattr(self._llfofb_dev, 'set_reforb' + plane.lower(), refhw)
+        func = getattr(self._llfofb_dev, 'set_reforb' + plane.lower())
+        func(refhw)
 
         # update readback PV
         self.run_callbacks(f'RefOrb{plane.upper()}-RB', list(ref.ravel()))


### PR DESCRIPTION
This PR updates FOFB related classes according to new FOFB controllers IOC version:
- now we have RefOrbX and RefOrbY PVs, instead of only RefOrb
- equivalently, we have InvRespMatRowX and InvRespMatRowY, instead of InvRespMatRow
- CCEnable-RB PV was renamed to CCEnable-Sts

Also, this PR:
- separates FOFB IOC periodic checks in two threads, one for correctors and the other to controllers
- add FOFB controllers physical triggers PVs to as_diagnostics config