### PR TITLE
Improve PSSearch and PS csdev

### DIFF
--- a/siriuspy/siriuspy/pwrsupply/csdev.py
+++ b/siriuspy/siriuspy/pwrsupply/csdev.py
@@ -866,6 +866,74 @@ def get_ps_modules(psmodel=None, psname=None):
     return sorted(modules)
 
 
+def get_ps_scopesourcemap(psname):
+    """Return PS modules for a power supply model."""
+    psmodel = _PSSearch.conv_psname_2_psmodel(psname)
+    psudcindex = _PSSearch.conv_psname_2_udcindex(psname)
+    if psmodel == 'FBP':
+        return {
+            'Output current [A]': 0xD000 + 2*psudcindex,
+            'Output voltage [V]': 0xC008 + 2*psudcindex,
+            'Tracking error [A or V]': 0xD008 + 2*psudcindex,
+            'DCLink voltage [V]': 0xC000 + 2*psudcindex,
+            'PWM duty cycle [p.u.]': 0xD040 + 2*psudcindex,
+        }
+    if psmodel == 'FAC_DCDC':
+        return {
+            'Output current [A]': 0xD006,
+            'Output voltage [V]': 0xC000,
+            'Tracking error [A or V]': 0xD008,
+            'DCLink voltage [V]': 0xD004,
+            'PWM duty cycle [p.u.]': 0xD040,
+        }
+    if psmodel == 'FAC_2S_DCDC':
+        return {
+            'Output current [A]': 0xD008,
+            'Tracking error [A or V]': 0xD00A,
+            'PWM duty cycle [p.u.]': 0xD040,
+        }
+    if psmodel == 'FAC_2S_ACDC':
+        return {
+            'Output voltage [V]': 0xD000 + 2*psudcindex,
+            'Tracking error [A or V]': 0xD00C + 14*psudcindex,
+            'PWM duty cycle [p.u.]': 0xD040 + 2*psudcindex,
+        }
+    if psmodel == 'FAC_2P4S_DCDC':
+        return {
+            'Output current [A]': 0xD008,
+            'Tracking error [A or V]': 0xD00A,
+            'PWM duty cycle [p.u.]': 0xD040,
+        }
+    if psmodel == 'FAC_2P4S_ACDC':
+        return {
+            'Output voltage [V]': 0xD000 + 2*psudcindex,
+            'Tracking error [A or V]': 0xD00C + 14*psudcindex,
+            'DCLink voltage [V]': 0xC000 + 2*psudcindex,
+            'PWM duty cycle [p.u.]': 0xD040 + 2*psudcindex,
+        }
+    if psmodel == 'FAP':
+        return {
+            'Output current [A]': 0xD006,
+            'Output voltage [V]': 0xC004,
+            'Tracking error [A or V]': 0xD008,
+            'DCLink voltage [V]': 0xD004,
+            'PWM duty cycle [p.u.]': 0xD040,
+        }
+    if psmodel == 'FAP_2P2S':
+        return {
+            'Output current [A]': 0xD008,
+            'Tracking error [A or V]': 0xD00A,
+            'PWM duty cycle [p.u.]': 0xD040,
+        }
+    if psmodel == 'FAP_4P':
+        return {
+            'Output current [A]': 0xD006,
+            'Tracking error [A or V]': 0xD008,
+            'PWM duty cycle [p.u.]': 0xD040,
+        }
+    return dict()
+
+
 # --- Auxiliary functions ---
 
 
@@ -1432,7 +1500,6 @@ def _get_ps_FOFB_propty_database():
             'lolo': 0, 'low': 0, 'lolim': 0,
             'hilim': 4194303, 'high': 4194303, 'hihi': 4194303},
         # Status and Alarms
-        'PSStatus-Mon': {'type': 'int', 'value': 0},
         'AlarmsAmp-Mon': {'type': 'int', 'value': 0},
         'AlarmsAmpLabels-Cte': {
             'type': 'string', 'count': len(_et.FOFB_ALARMS_AMP),

--- a/siriuspy/siriuspy/search/ps_search.py
+++ b/siriuspy/siriuspy/search/ps_search.py
@@ -325,6 +325,15 @@ class PSSearch:
         return dict_aux[dclink]
 
     @staticmethod
+    def conv_psname_2_udcindex(psname):
+        """Return power supply index in associated UDC."""
+        with PSSearch._lock:
+            PSSearch._reload_udc_2_bsmp_dict()
+        udc = PSSearch._bsmp_2_udc_dict[psname]
+        udcmap = PSSearch._udc_2_bsmp_dict[udc]
+        return [ps[0] for ps in udcmap].index(psname)
+
+    @staticmethod
     def get_linac_ps_sinap2sirius_dict():
         """Return PS name convertion dict."""
         return PSSearch._linac_ps_sinap2sirius

--- a/siriuspy/tests/pwrsupply/test_csdev.py
+++ b/siriuspy/tests/pwrsupply/test_csdev.py
@@ -31,6 +31,7 @@ PUB_INTERFACE = (
     'get_conv_propty_database',
     'get_ps_interlocks',
     'get_ps_modules',
+    'get_ps_scopesourcemap',
 )
 
 

--- a/siriuspy/tests/search/test_ps_search.py
+++ b/siriuspy/tests/search/test_ps_search.py
@@ -57,6 +57,7 @@ class TestPSSearch(TestCase):
         'conv_psname_2_udc',
         'conv_psname_2_dclink',
         'conv_dclink_2_psname',
+        'conv_psname_2_udcindex',
         'get_linac_ps_sinap2sirius_dict',
         'get_linac_ps_sirius2sinap_dict',
         'get_pstype_2_psnames_dict',


### PR DESCRIPTION
This PR adds methods to provide the information of the table of memory addresses for power supplies scope source ([available in wiki-sirius](https://wiki-sirius.lnls.br/mediawiki/index.php/ELP:Table_of_memory_addresses_for_power_supplies_Scope_Source)). 

Also (forgot to separate in a commit, sorry) this PR removes a nonexistent PV (PSStatus-Mon) listed in fast corrector database.