### PR TITLE
Fix siriuspy tests

### DIFF
--- a/.github/workflows/test-siriuspy.yml
+++ b/.github/workflows/test-siriuspy.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install pytest-testinfra
         run: |
           python -m pip install --upgrade pip
-          pip install flake8 pytest-testinfra
+          pip install flake8 pytest-testinfra wheel
 
       - name: Install eth-bridge-pru-serial485
         run: |


### PR DESCRIPTION
This PR fixes recent bug raised by new pip versions (other PRs are failing in tests because a new pip version is available which requires `wheel` for package installation).