### PR TITLE
Update FamBPMs device

### DIFF
--- a/siriuspy/siriuspy/devices/bpm.py
+++ b/siriuspy/siriuspy/devices/bpm.py
@@ -1290,8 +1290,7 @@ class FamBPMs(_Devices):
             int: code describing what happened:
                 -1: initial timestamps were not defined;
                 =0: data updated.
-                >0: index of the first BPM which did not update
-                    plus 1.
+                >0: index of the first BPM which did not update plus 1.
 
         """
         if self._initial_timestamps is None:

--- a/siriuspy/siriuspy/devices/bpm.py
+++ b/siriuspy/siriuspy/devices/bpm.py
@@ -1247,7 +1247,8 @@ class FamBPMs(_Devices):
         for flag in self._mturn_flags.values():
             flag.clear()
 
-    def mturn_reset_flags_and_update_initial_times(self, consider_sum=False):
+    def mturn_reset_flags_and_update_initial_timestamps(
+            self, consider_sum=False):
         """Set initial state to wait for orbit acquisition to start."""
         self.mturn_reset_flags()
         self.mturn_update_initial_timestamps(consider_sum)

--- a/siriuspy/siriuspy/devices/bpm.py
+++ b/siriuspy/siriuspy/devices/bpm.py
@@ -1320,8 +1320,7 @@ class FamBPMs(_Devices):
             int: code describing what happened:
                 -1: initial timestamps were not defined;
                 =0: data updated.
-                >0: index of the first BPM which did not update
-                    plus 1.
+                >0: index of the first BPM which did not update plus 1.
 
         """
         t00 = _time.time()

--- a/siriuspy/siriuspy/devices/bpm.py
+++ b/siriuspy/siriuspy/devices/bpm.py
@@ -1,4 +1,5 @@
-"""."""
+"""BPM devices."""
+
 import time as _time
 from threading import Event as _Flag
 import numpy as _np
@@ -14,9 +15,9 @@ class BPM(_Device):
     """BPM Device."""
 
     ACQSTATES_NOTOK = {
-            _csbpm.AcqStates.Error, _csbpm.AcqStates.No_Memory,
-            _csbpm.AcqStates.Too_Few_Samples,
-            _csbpm.AcqStates.Too_Many_Samples, _csbpm.AcqStates.Acq_Overflow}
+        _csbpm.AcqStates.Error, _csbpm.AcqStates.No_Memory,
+        _csbpm.AcqStates.Too_Few_Samples,
+        _csbpm.AcqStates.Too_Many_Samples, _csbpm.AcqStates.Acq_Overflow}
     ACQSTATES_STARTED = {
         _csbpm.AcqStates.Waiting, _csbpm.AcqStates.External_Trig,
         _csbpm.AcqStates.Data_Trig, _csbpm.AcqStates.Software_Trig,
@@ -887,7 +888,7 @@ class BPM(_Device):
 
 
 class FamBPMs(_Devices):
-    """."""
+    """Family of BPMs."""
 
     TIMEOUT = 10
     RFFEATT_MAX = 30
@@ -1257,9 +1258,9 @@ class FamBPMs(_Devices):
         Returns:
             int: code describing what happened:
                 -4: unknown error;
-                -3: initial orbit was not acquired before acquisition;
-                -2: TypeError ocurred (maybe because some of them are None);
-                -1: Orbits have different sizes;
+                -3: initial orbits were not defined;
+                -2: Orbits have different sizes;
+                -1: TypeError ocurred (maybe because some of them are None);
                 =0: Orbit updated.
                 >0: Index of the first BPM which did not update plus 1.
 
@@ -1289,9 +1290,9 @@ class FamBPMs(_Devices):
 
         if typ:
             return -1
-        elif max(sizes) != min(sizes):
+        if max(sizes) != min(sizes):
             return -2
-        elif _np.any(errs):
+        if _np.any(errs):
             return int(errs.nonzero()[0][0])+1
         return -4
 

--- a/siriuspy/siriuspy/devices/bpm.py
+++ b/siriuspy/siriuspy/devices/bpm.py
@@ -917,6 +917,7 @@ class FamBPMs(_Devices):
         super().__init__(devname, devs)
         self._bpm_names = bpm_names
         self._csbpm = devs[0].csdata
+        self._initial_orbs = None
 
     @property
     def bpm_names(self):
@@ -1226,9 +1227,10 @@ class FamBPMs(_Devices):
                 >0: Index of the first BPM which did not update plus 1.
 
         """
-        orbs0, self._initial_orbs = self._initial_orbs, None
-        if orbs0 is None:
+        if self._initial_orbs is None:
             return -3
+
+        orbs0 = self._initial_orbs
         while timeout > 0:
             t00 = _time.time()
             orbs = self.get_mturn_orbit(return_sum=consider_sum)


### PR DESCRIPTION
This PR updates FamBPMs device:
- remove wait methods that use orbit comparison
- add methods to verify that data was updated using PVs timestamp
- fix docstrings and implement some linting suggestions

Maybe the changes here will trigger changes in `apsuite`, I will verify it, but if you guys notice some undesired API change, please let me know.