### PR TITLE
Fix bug in Device class

### DIFF
--- a/siriuspy/siriuspy/devices/device.py
+++ b/siriuspy/siriuspy/devices/device.py
@@ -151,7 +151,7 @@ class Device:
         pvs = dict()
         for propty in self._properties:
             pvname = self._get_pvname(devname, propty)
-            auto_monitor = self._auto_mon or not pvname.endswith('-Mon')
+            auto_monitor = self._auto_mon and not pvname.endswith('-Mon')
             in_sim = _Simulation.pv_check(pvname)
             pvclass = _PVSim if in_sim else _PV
             pvs[propty] = pvclass(

--- a/siriuspy/siriuspy/devices/device.py
+++ b/siriuspy/siriuspy/devices/device.py
@@ -151,6 +151,8 @@ class Device:
         pvs = dict()
         for propty in self._properties:
             pvname = self._get_pvname(devname, propty)
+            # avoid keeping auto_monitor enabled for -Mon PVs as they usually
+            # have a high update rate which can generate a lot of CPU load
             auto_monitor = self._auto_mon and not pvname.endswith('-Mon')
             in_sim = _Simulation.pv_check(pvname)
             pvclass = _PVSim if in_sim else _PV


### PR DESCRIPTION
This PR fixes a bug we noted yesterday during machine studies, this commit changes Device class to create PVs with the correct auto_monitor setting. Thanks to @fernandohds564 and @ericonr for helping me debug this.