### PR TITLE
Update PSDiag IOC

### DIFF
--- a/siriuspy/siriuspy/diagsys/psdiag/csdev.py
+++ b/siriuspy/siriuspy/diagsys/psdiag/csdev.py
@@ -15,7 +15,9 @@ class ETypes(_csdev.ETypes):
         'Interlocks',
         'Alarms',
         'OpMode-(Sel|Sts) are different',
-        'Reserved')
+        'Reserved',
+        'Reserved',
+        )
 
     DIAG_STATUS_LABELS_LI = (
         'PS Disconnected/Comm. Broken',
@@ -24,7 +26,9 @@ class ETypes(_csdev.ETypes):
         'Interlocks',
         'Reserved',
         'Reserved',
-        'Reserved')
+        'Reserved',
+        'Reserved',
+        )
 
     DIAG_STATUS_LABELS_FC = (
         'PS Disconnected',
@@ -33,7 +37,9 @@ class ETypes(_csdev.ETypes):
         'Reserved',
         'Alarms',
         'OpMode-(Sel|Sts) are different',
-        'Reserved')
+        'Reserved',
+        'Triggered mode enabled',
+        )
 
     DIAG_STATUS_LABELS_BO = (
         'PS Disconnected/Comm. Broken',
@@ -42,7 +48,9 @@ class ETypes(_csdev.ETypes):
         'Interlocks',
         'Alarms',
         'OpMode-(Sel|Sts) are different',
-        'Wfm error exceeded tolerance')
+        'Wfm error exceeded tolerance',
+        'Reserved',
+        )
 
 
 _et = ETypes  # syntactic sugar

--- a/siriuspy/siriuspy/diagsys/psdiag/csdev.py
+++ b/siriuspy/siriuspy/diagsys/psdiag/csdev.py
@@ -33,7 +33,7 @@ class ETypes(_csdev.ETypes):
     DIAG_STATUS_LABELS_FC = (
         'PS Disconnected',
         'PwrState-Sts Off',
-        'Current-(SP|RB) are different',
+        'Current-(SP|Ref-Mon|Mon) are different',
         'Reserved',
         'Alarms',
         'OpMode-(Sel|Sts) are different',

--- a/siriuspy/siriuspy/diagsys/psdiag/main.py
+++ b/siriuspy/siriuspy/diagsys/psdiag/main.py
@@ -19,9 +19,13 @@ class PSDiagApp(_App):
             devname = SiriusPVName(psname).substitute(prefix=self._prefix)
 
             # DiagCurrentDiff-Mon
-            pvs = [None, None]
+            nrpvs = 4 if devname.sec != 'LI' else 2
+            pvs = [None]*nrpvs
             pvs[_PSDiffPV.CURRT_SP] = devname + ':Current-SP'
             pvs[_PSDiffPV.CURRT_MON] = devname + ':Current-Mon'
+            if devname.sec != 'LI':
+                pvs[_PSDiffPV.CURRT_REF] = devname + ':CurrentRef-Mon'
+                pvs[_PSDiffPV.OPMODESTS] = devname + ':OpMode-Sts'
             pvo = _ComputedPV(
                 psname + ':DiagCurrentDiff-Mon', _PSDiffPV(), self._queue,
                 pvs, monitor=False)

--- a/siriuspy/siriuspy/diagsys/psdiag/main.py
+++ b/siriuspy/siriuspy/diagsys/psdiag/main.py
@@ -42,7 +42,7 @@ class PSDiagApp(_App):
                         alarm_list.extend(
                             [aux+':'+alm for alm in intlks if 'Alarm' in alm])
 
-                nbpvs = 4 if psname.dev in ['FCH', 'FCV'] else 5
+                nbpvs = 5
                 pvs = [None]*(nbpvs+len(intlk_list)+len(alarm_list))
                 pvs[_PSStatusPV.PWRSTE_STS] = devname + ':PwrState-Sts'
                 pvs[_PSStatusPV.CURRT_DIFF] = devname + ':DiagCurrentDiff-Mon'
@@ -50,6 +50,8 @@ class PSDiagApp(_App):
                 pvs[_PSStatusPV.OPMODE_STS] = devname + ':OpMode-Sts'
                 if psname.dev not in ['FCH', 'FCV']:
                     pvs[_PSStatusPV.WAVFRM_MON] = devname + ':Wfm-Mon'
+                else:
+                    pvs[_PSStatusPV.TRIGEN_STS] = devname + ':TrigEn-Sts'
 
                 computer.INTLK_PVS = list()
                 for idx, intlk in enumerate(intlk_list):

--- a/siriuspy/siriuspy/diagsys/psdiag/pvs.py
+++ b/siriuspy/siriuspy/diagsys/psdiag/pvs.py
@@ -32,13 +32,14 @@ class PSDiffPV:
 class PSStatusPV:
     """Power Supply Status PV."""
 
-    BIT_PSCONNECT = 0b0000001
-    BIT_PWRSTATON = 0b0000010
-    BIT_CURRTDIFF = 0b0000100
-    BIT_INTERLOCK = 0b0001000
-    BIT_ALARMSSET = 0b0010000
-    BIT_OPMODEDIF = 0b0100000
-    BIT_BOWFMDIFF = 0b1000000
+    BIT_PSCONNECT = 0b00000001
+    BIT_PWRSTATON = 0b00000010
+    BIT_CURRTDIFF = 0b00000100
+    BIT_INTERLOCK = 0b00001000
+    BIT_ALARMSSET = 0b00010000
+    BIT_OPMODEDIF = 0b00100000
+    BIT_BOWFMDIFF = 0b01000000
+    BIT_TRIGMDENB = 0b10000000
 
     PWRSTE_STS = 0
     CURRT_DIFF = 1
@@ -48,6 +49,7 @@ class PSStatusPV:
     OPMODE_SEL = 2
     OPMODE_STS = 3
     WAVFRM_MON = 4
+    TRIGEN_STS = 4
 
     DTOLWFM_DICT = dict()
 
@@ -99,6 +101,7 @@ class PSStatusPV:
             value |= PSStatusPV.BIT_ALARMSSET
             value |= PSStatusPV.BIT_OPMODEDIF
             value |= PSStatusPV.BIT_BOWFMDIFF
+            value |= PSStatusPV.BIT_TRIGMDENB
             return {'value': value}
 
         # pwrstate?
@@ -152,6 +155,12 @@ class PSStatusPV:
                 if alarmval != 0 or alarmval is None:
                     value |= PSStatusPV.BIT_ALARMSSET
                     break
+
+            # triggered mode enable?
+            if psname.dev in ['FCH', 'FCV']:
+                trigen = computed_pv.pvs[PSStatusPV.TRIGEN_STS].value
+                if trigen or trigen is None:
+                    value |= PSStatusPV.BIT_TRIGMDENB
 
         else:
             # current-diff?


### PR DESCRIPTION
This PR updates PSDiag IOC:
- DiagStatus PV now also checks whether fast correctors are with triggered mode disabled;
- DiagCurrentDiff PV calculates Diff considering CurrentRef-Mon for fast correctors when those are in FOFB mode, and DiagStatus PV checks CurrentDiff also in FOFB mode.