### PR TITLE
Change SOFB to use SlowOrb from Orbit IOC.

### DIFF
--- a/siriuspy/siriuspy/sofb/csdev.py
+++ b/siriuspy/siriuspy/sofb/csdev.py
@@ -42,7 +42,7 @@ class ETypes(_csdev.ETypes):
         'TimingConnected', 'TimingConfigured', 'RFConnected', 'RFPwrStateOn')
     STS_LBLS_ORB = (
         'TimingConnected', 'TimingConfigured', 'BPMsConnected',
-        'BPMsEnabled', 'BPMsConfigured')
+        'BPMsEnabled', 'BPMsConfigured', 'OrbRawConnected')
     STS_LBLS_GLOB = ('Ok', 'NotOk')
 
 

--- a/siriuspy/siriuspy/sofb/csdev.py
+++ b/siriuspy/siriuspy/sofb/csdev.py
@@ -62,7 +62,7 @@ class ConstTLines(_csdev.Const):
     TINY_KICK = 1e-3  # [urad]
     DEF_MAX_ORB_DISTORTION = 50  # [um]
     ACQRATE_TRIGMODE = 2  # [Hz]
-    ACQRATE_SLOWORB = 12  # [Hz]
+    ACQRATE_SLOWORB = 60  # [Hz]
     BPMsFreq = 10.48  # [Hz]
 
     TrigAcqCtrl = _csbpm.AcqEvents

--- a/siriuspy/siriuspy/sofb/orbit.py
+++ b/siriuspy/siriuspy/sofb/orbit.py
@@ -750,6 +750,9 @@ class EpicsOrbit(BaseOrbit):
         if self._sloworb_raw_timeout_pv.connected:
             timeout = self._sloworb_raw_timeout_pv.value or timeout
         if not self._new_orbit_raw.wait(timeout=timeout):
+            msg = 'ERR: Raw orbit did not update.'
+            self._update_log(msg)
+            _log.error(msg[5:])
             return
         self._new_orbit_raw.clear()
 


### PR DESCRIPTION
Hi guys, this PR has a huge simplification of the SOFB code, thanks to @ericonr.
The new orbit IOC gets the orbit from all BPMs using a similiar algorithm as the one SOFB used to use, but it is much faster and reliable because it is not implemented in python.

At first I tested the sanity of the PV provided by the orbit IOC:
```python3
import time

import numpy as np
import matplotlib.pyplot as mplt

from siriuspy.epics import PV
from siriuspy.sofb.orbit import EpicsOrbit

orbs = []
tims = []
tstmps = []
def callback(pvname, value, **kwrgs):
    orbs.append(value)
    tims.append(time.time())
    tstmps.append(kwrgs['timestamp'])

orb_pv = PV('SI-Glob:AP-SOFB:SlowOrbRaw-Mon')
orb_pv.wait_for_connection()

orb_pv.add_callback(callback)
time.sleep(10)
orb_pv.clear_callbacks()
orbs = np.array(orbs)
tims = np.array(tims)
tstmps = np.array(tstmps)

fig, (ax, ay) = mplt.subplots(2, 1, sharex=True)
ax.plot(np.diff(tims), label='Client Times')
ax.plot(np.diff(tstmps), label='Timestamp')
ax.axhline(0.11, ls='--', color='k')
ay.plot(np.diff(orbs, axis=0), 'o')

ax.legend(loc='best')
ax.grid(True, alpha=0.5, ls='--', lw=1)
ay.grid(True, alpha=0.5, ls='--', lw=1)
ax.set_ylabel('Time Intervals [s]')
ay.set_ylabel('Delta Orbits [um]')
ay.set_xlabel('Index')
ay.set_ylim([-1e-6, 1e-6])
fig.tight_layout()
fig.show()
```
which showed that the values were being updated correctly and within the appropriate time.

Then, I tested the new version of SOFB interacting with orbit PV:
```python3
import time

import numpy as np
import matplotlib.pyplot as mplt

from siriuspy.epics import PV
from siriuspy.sofb.orbit import EpicsOrbit

orb = EpicsOrbit('SI')

while orb.status:
    time.sleep(0.1)

orbs = []
tims = []
tstmps = []
for _ in range(100):
    t0_ = time.time()
    orbs.append(orb.get_orbit(synced=True))
    tims.append(time.time())
    tstmps.append(orb._sloworb_raw_pv.timestamp)
orbs = np.array(orbs)
tims = np.array(tims)
tstmps = np.array(tstmps)

fig, (ax, ay) = mplt.subplots(2, 1, sharex=True)
ax.plot(np.diff(tims), label='Client Times')
ax.plot(np.diff(tstmps), label='Timestamp')
ax.axhline(0.11, ls='--', color='k')
ay.plot(np.diff(orbs, axis=0), 'o')

ax.legend(loc='best')
ax.grid(True, alpha=0.5, ls='--', lw=1)
ay.grid(True, alpha=0.5, ls='--', lw=1)
ax.set_ylabel('Time Intervals [s]')
ay.set_ylabel('Delta Orbits [um]')
ay.set_xlabel('Index')
ay.set_ylim([-1e-6, 1e-6])
fig.tight_layout()
fig.show()
```
which showed that gets the values of the PV correctly and in synchrony with its update.
During execution, this script consumed approximately 14% of one CPU in my work computer.

I also tested the old version of the SOFB IOC, which gathered the orbit by creating 16 auxiliary processes:
```python3
import time

import numpy as np
import matplotlib.pyplot as mplt

from siriuspy.epics import PV
from siriuspy.sofb.orbit import EpicsOrbit

orb = EpicsOrbit('SI')

time.sleep(10)

orbs = []
tims = []
for _ in range(100):
    t0_ = time.time()
    orbs.append(orb.get_orbit(synced=True, timeout=1/5))
    tims.append(time.time())
orbs = np.array(orbs)
tims = np.array(tims)

fig, (ax, ay) = mplt.subplots(2, 1, sharex=True)
ax.plot(np.diff(tims), label='Client Times')
ax.axhline(0.11, ls='--', color='k')
ay.plot(np.diff(orbs, axis=0), 'o')

ax.grid(True, alpha=0.5, ls='--', lw=1)
ay.grid(True, alpha=0.5, ls='--', lw=1)
ax.set_ylabel('Time Intervals [s]')
ay.set_ylabel('Delta Orbits [um]')
ay.set_xlabel('Index')
ay.set_ylim([-1e-6, 1e-6])
fig.tight_layout()
fig.show()
```
this test showed that for some acquisitions the orbit is the same as the previous orbit.
This version consumed 5% of each of the auxiliary processes and 3% of the main process.