### PR TITLE
Update machine report scripts

### DIFF
--- a/siriuspy/siriuspy/machshift/gensumm_macreport.py
+++ b/siriuspy/siriuspy/machshift/gensumm_macreport.py
@@ -7,21 +7,33 @@ from siriuspy.machshift.macreport import MacReport
 
 # failure statistics per month
 intervals = [
-    [Time(2021, 1, 1, 0, 0), Time(2021, 1, 31, 23, 59)],
-    [Time(2021, 2, 1, 0, 0), Time(2021, 2, 28, 23, 59)],
-    [Time(2021, 3, 1, 0, 0), Time(2021, 3, 31, 23, 59)],
-    [Time(2021, 4, 1, 0, 0), Time(2021, 4, 30, 23, 59)],
-    [Time(2021, 5, 1, 0, 0), Time(2021, 5, 31, 23, 59)],
-    [Time(2021, 6, 1, 0, 0), Time(2021, 6, 30, 23, 59)],
-    [Time(2021, 7, 1, 0, 0), Time(2021, 7, 31, 23, 59)],
-    [Time(2021, 8, 1, 0, 0), Time(2021, 8, 31, 23, 59)],
-    [Time(2021, 9, 1, 0, 0), Time(2021, 9, 30, 23, 59)],
-    [Time(2021, 10, 1, 0, 0), Time(2021, 10, 31, 23, 59)],
-    [Time(2021, 11, 1, 0, 0), Time(2021, 11, 30, 23, 59)],
-    [Time(2021, 12, 1, 0, 0), Time(2021, 12, 31, 23, 59)],
-    [Time(2022, 1, 1, 0, 0), Time(2022, 1, 31, 23, 59)],
-    [Time(2022, 2, 1, 0, 0), Time(2022, 2, 28, 23, 59)],
-    [Time(2022, 3, 1, 0, 0), Time(2022, 3, 31, 23, 59)],
+    [Time(2021, 1, 1, 0, 0), Time(2021, 1, 31, 23, 59, 59)],
+    [Time(2021, 2, 1, 0, 0), Time(2021, 2, 28, 23, 59, 59)],
+    [Time(2021, 3, 1, 0, 0), Time(2021, 3, 31, 23, 59, 59)],
+    [Time(2021, 4, 1, 0, 0), Time(2021, 4, 30, 23, 59, 59)],
+    [Time(2021, 5, 1, 0, 0), Time(2021, 5, 31, 23, 59, 59)],
+    [Time(2021, 6, 1, 0, 0), Time(2021, 6, 30, 23, 59, 59)],
+    [Time(2021, 7, 1, 0, 0), Time(2021, 7, 31, 23, 59, 59)],
+    [Time(2021, 8, 1, 0, 0), Time(2021, 8, 31, 23, 59, 59)],
+    [Time(2021, 9, 1, 0, 0), Time(2021, 9, 30, 23, 59, 59)],
+    [Time(2021, 10, 1, 0, 0), Time(2021, 10, 31, 23, 59, 59)],
+    [Time(2021, 11, 1, 0, 0), Time(2021, 11, 30, 23, 59, 59)],
+    [Time(2021, 12, 1, 0, 0), Time(2021, 12, 31, 23, 59, 59)],
+    [Time(2022, 1, 1, 0, 0), Time(2022, 1, 31, 23, 59, 59)],
+    [Time(2022, 2, 1, 0, 0), Time(2022, 2, 28, 23, 59, 59)],
+    [Time(2022, 3, 1, 0, 0), Time(2022, 3, 31, 23, 59, 59)],
+    [Time(2022, 4, 1, 0, 0), Time(2022, 4, 30, 23, 59, 59)],
+    [Time(2022, 5, 1, 0, 0), Time(2022, 5, 31, 23, 59, 59)],
+    [Time(2022, 6, 1, 0, 0), Time(2022, 6, 30, 23, 59, 59)],
+    [Time(2022, 7, 1, 0, 0), Time(2022, 7, 31, 23, 59, 59)],
+    [Time(2022, 8, 1, 0, 0), Time(2022, 8, 31, 23, 59, 59)],
+    [Time(2022, 9, 1, 0, 0), Time(2022, 9, 30, 23, 59, 59)],
+    [Time(2022, 10, 1, 0, 0), Time(2022, 10, 31, 23, 59, 59)],
+    [Time(2022, 11, 1, 0, 0), Time(2022, 11, 30, 23, 59, 59)],
+    [Time(2022, 12, 1, 0, 0), Time(2022, 12, 31, 23, 59, 59)],
+    [Time(2023, 1, 1, 0, 0), Time(2023, 1, 31, 23, 59, 59)],
+    [Time(2023, 2, 1, 0, 0), Time(2023, 2, 28, 23, 59, 59)],
+    [Time(2023, 3, 1, 0, 0), Time(2023, 3, 31, 23, 59, 59)],
 ]
 
 macreports = dict()
@@ -34,6 +46,7 @@ for intvl in intervals:
 
 mtbfs, mttrs, reliabs = dict(), dict(), dict()
 progrmd, delivd, usertot = dict(), dict(), dict()
+currmean, currstd = dict(), dict()
 stable, unstable, relstable = dict(), dict(), dict()
 for date, macr in macreports.items():
     mtbfs[date] = macr.usershift_time_between_failures_average
@@ -42,16 +55,18 @@ for date, macr in macreports.items():
     progrmd[date] = macr.usershift_progmd_time
     delivd[date] = macr.usershift_delivd_time
     usertot[date] = macr.usershift_total_time
+    currmean[date] = macr.usershift_current_average
+    currstd[date] = macr.usershift_current_stddev
     stable[date] = macr.usershift_total_stable_beam_time
     unstable[date] = macr.usershift_total_unstable_beam_time
     relstable[date] = macr.usershift_relative_stable_beam_time
 
-str_ = '{:<10s}' + '{:>16s}'*9
+str_ = '{:<10s}' + '{:>16s}'*9 + '{:>20s}'
 print(str_.format(
     'Y-M', 'MTBF', 'MTTR',
     'Reliability', 'Progrmd hours', 'Delivd hours', 'Total hours',
-    '% stable hours', 'Stable hours', 'Unstable hours'))
-str_ = '{:<10s}' + '    {:>12.3f}'*9
+    '% stable hours', 'Stable hours', 'Unstable hours', 'Current (Avg±Std)'))
+str_ = '{:<10s}' + '    {:>12.3f}'*9 + '    {:4.3f} ± {:4.3f}'
 for date in macreports:
     print(str_.format(
         str(date.year)+'-'+str(date.month),
@@ -64,6 +79,7 @@ for date in macreports:
         relstable[date],
         stable[date],
         unstable[date],
+        currmean[date], currstd[date],
     ))
 
 fig, axs = plt.subplots(3, 1, sharex=True)
@@ -88,20 +104,33 @@ fig.show()
 
 # programmed vs. delivered hours
 macr = MacReport()
-macr.connector.timeout = 120
-macr.time_start = Time(2021, 3, 1, 0, 0)
-macr.time_stop = Time(2022, 3, 31, 23, 59)
+macr.connector.timeout = 300
+macr.time_start = Time(2022, 4, 1, 0, 0)
+macr.time_stop = Time(2023, 3, 31, 23, 59, 59)
 macr.update()
 
-print('MTBF', macr.usershift_time_between_failures_average)
-print('MTTR', macr.usershift_time_to_recover_average)
-print('Reliability', macr.usershift_beam_reliability)
-print('Progrmd hours', macr.usershift_progmd_time)
-print('Delivd hours', macr.usershift_delivd_time)
-print('Total hours', macr.usershift_total_time)
-print('% stable hours', macr.usershift_relative_stable_beam_time)
-print('Stable hours', macr.usershift_total_stable_beam_time)
-print('Unstable hours', macr.usershift_total_unstable_beam_time)
+str_ = '{:<10s}' + '{:>16s}'*9 + '{:>20s}'
+print(str_.format(
+    'Y-M', 'MTBF', 'MTTR',
+    'Reliability', 'Progrmd hours', 'Delivd hours', 'Total hours',
+    '% stable hours', 'Stable hours', 'Unstable hours', 'Current (Avg±Std)'))
+str_ = '{:<10s}' + '    {:>12.3f}'*9 + '    {:4.3f} ± {:4.3f}'
+print(
+    str_.format(
+        str(macr.time_start.year)+'-'+str(macr.time_start.month) + ' a ' +
+        str(macr.time_stop.year)+'-'+str(macr.time_stop.month),
+        macr.usershift_time_between_failures_average,
+        macr.usershift_time_to_recover_average,
+        macr.usershift_beam_reliability,
+        macr.usershift_progmd_time,
+        macr.usershift_delivd_time,
+        macr.usershift_total_time,
+        macr.usershift_relative_stable_beam_time,
+        macr.usershift_total_stable_beam_time,
+        macr.usershift_total_unstable_beam_time,
+        macr.usershift_current_average,
+        macr.usershift_current_stddev,
+    ))
 
 rd = macr.raw_data
 dtimes = np.diff(rd['Timestamp'])

--- a/siriuspy/siriuspy/machshift/macreport.py
+++ b/siriuspy/siriuspy/machshift/macreport.py
@@ -1559,8 +1559,8 @@ class MacReport:
             beg_val += [beg_idcs.size-1]
             beg1, beg2 = beg_idcs[beg_val], beg_idcs[beg_val] + 15
             if beg2[-1] > self._users_shift_delivd_values.size-1:
-                beg1.pop()
-                beg2.pop()
+                beg1 = _np.delete(beg1, -1)
+                beg2 = _np.delete(beg2, -1)
             beg_val = [i for i in range(beg1.size) if not
                        any([beg1[i] < e < beg2[i] for e in end_idcs])]
             beg1, beg2 = beg1[beg_val], beg2[beg_val]
@@ -1577,8 +1577,8 @@ class MacReport:
                              if end_idcs[i]-end_idcs[i-1] > 15]
             end1, end2 = end_idcs[end_val] - 15, end_idcs[end_val]
             if end1[0] < 0:
-                end1.pop(0)
-                end2.pop(0)
+                end1 = _np.delete(end1, 0)
+                end2 = _np.delete(end2, 0)
             end_val = [i for i in range(end1.size-1) if not
                        any([end1[i] < b < end2[i] for b in beg_idcs])]
             end1, end2 = end1[end_val], end2[end_val]

--- a/siriuspy/siriuspy/machshift/macschedule.py
+++ b/siriuspy/siriuspy/machshift/macschedule.py
@@ -117,6 +117,7 @@ class MacScheduleData:
         databyshift = list()
         databyday = list()
         datainicurr = list()
+        flag_bit, inicurr = 0, 0.0
         for datum in data:
             if len(datum) < 2:
                 raise Exception(
@@ -126,9 +127,9 @@ class MacScheduleData:
             month, day = int(datum[0]), int(datum[1])
             if len(datum) == 2:
                 timestamp = _Time(year, month, day, 0, 0).timestamp()
-                databyshift.append((timestamp, 0))
-                databyday.append((timestamp, 0))
-                datainicurr.append((timestamp, 0.0))
+                databyshift.append((timestamp, flag_bit))
+                databyday.append((timestamp, flag_bit))
+                datainicurr.append((timestamp, inicurr))
             else:
                 timestamp = _Time(year, month, day, 0, 0).timestamp()
                 databyday.append((timestamp, 1))

--- a/siriuspy/siriuspy/machshift/macschedule.py
+++ b/siriuspy/siriuspy/machshift/macschedule.py
@@ -50,12 +50,20 @@ class MacScheduleData:
         return _np.sum(tags) if begin != end else 0
 
     @staticmethod
-    def get_users_shift_day_count(begin, end):
+    def get_users_shift_day_count(begin, end, count_sundays=True):
         """Get users shift day count for a period."""
         begin, end = MacScheduleData._handle_interval_data(begin, end)
-        _, tags = MacScheduleData._get_numeric_data_for_interval(
+        tims, tags = MacScheduleData._get_numeric_data_for_interval(
             begin, end, dtype='macsched_byday')
-        return _np.sum(tags) if begin != end else 0
+
+        count = 0
+        if begin != end:
+            for tim, tag in zip(tims, tags):
+                weekday = _Time(tim).weekday()
+                if (weekday == 6 and count_sundays) or weekday != 6:
+                    count += tag
+        return count
+
 
     @staticmethod
     def is_user_shift_programmed(

--- a/siriuspy/siriuspy/machshift/savedata_macreport.py
+++ b/siriuspy/siriuspy/machshift/savedata_macreport.py
@@ -1,0 +1,70 @@
+
+import numpy as np
+import pandas as pd
+from siriuspy.clientarch.time import Time
+from siriuspy.machshift.macreport import MacReport
+
+# determine interval
+time_start = Time(2022, 1, 1, 0, 0)
+time_stop = Time(2022, 12, 31, 23, 59, 59)
+
+# get data from interval
+macr = MacReport()
+macr.connector.timeout = 300
+macr.time_start = time_start
+macr.time_stop = time_stop
+macr.update()
+
+# print small report
+str_ = '{:<10s}' + '{:>16s}'*9 + '{:>20s}'
+print(str_.format(
+    'Y-M', 'MTBF', 'MTTR',
+    'Reliability', 'Progrmd hours', 'Delivd hours', 'Total hours',
+    '% stable hours', 'Stable hours', 'Unstable hours', 'Current (Avg±Std)'))
+str_ = '{:<10s}' + '    {:>12.3f}'*9 + '    {:4.3f} ± {:4.3f}'
+print(
+    str_.format(
+        str(macr.time_start.year)+'-'+str(macr.time_start.month) + ' a ' +
+        str(macr.time_stop.year)+'-'+str(macr.time_stop.month),
+        macr.usershift_time_between_failures_average,
+        macr.usershift_time_to_recover_average,
+        macr.usershift_beam_reliability,
+        macr.usershift_progmd_time,
+        macr.usershift_delivd_time,
+        macr.usershift_total_time,
+        macr.usershift_relative_stable_beam_time,
+        macr.usershift_total_stable_beam_time,
+        macr.usershift_total_unstable_beam_time,
+        macr.usershift_current_average,
+        macr.usershift_current_stddev,
+    ))
+
+# get data of interest
+raw_data = macr.raw_data.copy()
+raw_data.pop('Shift')
+raw_data.pop('EgunModes')
+raw_data.pop('Distortions')
+raw_data.pop('UserShiftTotal')
+raw_data.pop('UserShiftStable')
+failures = raw_data.pop('Failures')
+raw_data['Failures - SubsystemsNOk'] = np.asarray(failures['SubsystemsNOk'], dtype=int)
+raw_data['Failures - NoEBeam'] = np.asarray(failures['NoEBeam'], dtype=int)
+raw_data['Failures - WrongShift'] = np.asarray(failures['WrongShift'], dtype=int)
+raw_data['TimeDate'] = [Time(t).get_iso8601() for t in raw_data['Timestamp']]
+
+# stored data in specific order
+order = [
+    'Timestamp', 'TimeDate', 'Current',
+    'Failures - SubsystemsNOk', 'Failures - NoEBeam', 'Failures - WrongShift',
+    'UserShiftProgmd', 'UserShiftInitCurr', 'UserShiftDelivd']
+data = {k: raw_data[k] for k in order}
+
+# save data to csv
+df = pd.DataFrame.from_dict(data)
+df.to_csv('raw_data_machine_report_2022.csv', index=False, header=True)
+
+# check hour numbers: each point is equivalent to 5s, converting to hours
+programmed = sum(data['UserShiftProgmd'])*5/60/60
+delivered = sum(data['UserShiftDelivd'])*5/60/60
+print('Programmed hours:', programmed)
+print('Delivered hours:', delivered)


### PR DESCRIPTION
This PR:
- Adapts MacScheduleData class to correct count shifts that last longer than a day
- Adds snippet to generate raw data .csv file (used for internal audit activities)
- Updates script for generating machine report summary
- Adds minor improvement in MacScheduleData.get_users_shift_day_count to make it possible to choose whether to count sunday as a user shift day