### PR TITLE
Allow shorter topup periods

### DIFF
--- a/siriuspy/siriuspy/injctrl/csdev.py
+++ b/siriuspy/siriuspy/injctrl/csdev.py
@@ -396,27 +396,23 @@ def get_biasfb_database():
     """."""
     dbase = {
         'LoopState-Sel': {
-            'type': 'enum', 'value': _ct.OffOn.Off, 'enums': _et.OFF_ON,
+            'type': 'enum', 'value': _ct.OffOn.On, 'enums': _et.OFF_ON,
             'unit': 'Off_On'},
         'LoopState-Sts': {
-            'type': 'enum', 'value': _ct.OffOn.Off, 'enums': _et.OFF_ON,
+            'type': 'enum', 'value': _ct.OffOn.On, 'enums': _et.OFF_ON,
             'unit': 'Off_On'},
         'MinVoltage-SP': {
             'type': 'float', 'value': -52, 'unit': 'V',
-            'prec': 1, 'lolim': -120, 'low': -120, 'lolo': -120,
-            'hilim': -30.0, 'high': -30.0, 'hihi': -30.0},
+            'prec': 1, 'lolim': -120, 'hilim': -30.0},
         'MinVoltage-RB': {
             'type': 'float', 'value': -52, 'unit': 'V',
-            'prec': 1, 'lolim': -120, 'low': -120, 'lolo': -120,
-            'hilim': -30.0, 'high': -30.0, 'hihi': -30.0},
+            'prec': 1, 'lolim': -120, 'hilim': -30.0},
         'MaxVoltage-SP': {
-            'type': 'float', 'value': -40, 'unit': 'V',
-            'prec': 1, 'lolim': -120, 'low': -120, 'lolo': -120,
-            'hilim': -30.0, 'high': -30.0, 'hihi': -30.0},
+            'type': 'float', 'value': -45, 'unit': 'V',
+            'prec': 1, 'lolim': -120, 'hilim': -30.0},
         'MaxVoltage-RB': {
-            'type': 'float', 'value': -40, 'unit': 'V',
-            'prec': 1, 'lolim': -120, 'low': -120, 'lolo': -120,
-            'hilim': -30.0, 'high': -30.0, 'hihi': -30.0},
+            'type': 'float', 'value': -45, 'unit': 'V',
+            'prec': 1, 'lolim': -120, 'hilim': -30.0},
 
         'ModelType-Sel': {
             'type': 'enum', 'value': _ct.BiasFBModelTypes.GaussianProcess,
@@ -426,52 +422,34 @@ def get_biasfb_database():
             'enums': _et.BIASFB_MODEL_TYPES, 'unit': 'Lin_GP'},
         'ModelMaxNrPts-SP': {
             'type': 'int', 'value': 20, 'unit': '#',
-            'lolim': 2, 'low': 2, 'lolo': 2,
-            'hilim': _ct.BIASFB_MAX_DATA_SIZE,
-            'high': _ct.BIASFB_MAX_DATA_SIZE,
-            'hihi': _ct.BIASFB_MAX_DATA_SIZE},
+            'lolim': 2, 'hilim': _ct.BIASFB_MAX_DATA_SIZE},
         'ModelMaxNrPts-RB': {
             'type': 'int', 'value': 20, 'unit': '#',
-            'lolim': 0, 'low': 0, 'lolo': 0,
-            'hilim': _ct.BIASFB_MAX_DATA_SIZE,
-            'high': _ct.BIASFB_MAX_DATA_SIZE,
-            'hihi': _ct.BIASFB_MAX_DATA_SIZE},
+            'lolim': 2, 'hilim': _ct.BIASFB_MAX_DATA_SIZE},
         'ModelNrPts-Mon': {
             'type': 'int', 'value': 20, 'unit': '#',
-            'lolim': 2, 'low': 2, 'lolo': 2,
-            'hilim': _ct.BIASFB_MAX_DATA_SIZE,
-            'high': _ct.BIASFB_MAX_DATA_SIZE,
-            'hihi': _ct.BIASFB_MAX_DATA_SIZE},
+            'lolim': 2, 'hilim': _ct.BIASFB_MAX_DATA_SIZE},
         'ModelFitParamsNow-Cmd': {'type': 'int', 'value': 0},
         'ModelAutoFitParams-Sel': {
-            'type': 'enum', 'value': _ct.OffOn.Off, 'enums': _et.OFF_ON,
+            'type': 'enum', 'value': _ct.OffOn.On, 'enums': _et.OFF_ON,
             'unit': 'Off_On'},
         'ModelAutoFitParams-Sts': {
-            'type': 'enum', 'value': _ct.OffOn.Off, 'enums': _et.OFF_ON,
+            'type': 'enum', 'value': _ct.OffOn.On, 'enums': _et.OFF_ON,
             'unit': 'Off_On'},
         'ModelAutoFitEveryNrPts-SP': {
-            'type': 'int', 'value': 10, 'unit': '#',
-            'lolim': 1, 'low': 1, 'lolo': 1,
-            'hilim': _ct.BIASFB_MAX_DATA_SIZE,
-            'high': _ct.BIASFB_MAX_DATA_SIZE,
-            'hihi': _ct.BIASFB_MAX_DATA_SIZE},
+            'type': 'int', 'value': 1, 'unit': '#',
+            'lolim': 1, 'hilim': _ct.BIASFB_MAX_DATA_SIZE},
         'ModelAutoFitEveryNrPts-RB': {
-            'type': 'int', 'value': 10, 'unit': '#',
-            'lolim': 1, 'low': 1, 'lolo': 1,
-            'hilim': _ct.BIASFB_MAX_DATA_SIZE,
-            'high': _ct.BIASFB_MAX_DATA_SIZE,
-            'hihi': _ct.BIASFB_MAX_DATA_SIZE},
+            'type': 'int', 'value': 1, 'unit': '#',
+            'lolim': 1, 'hilim': _ct.BIASFB_MAX_DATA_SIZE},
         'ModelNrPtsAfterFit-Mon': {
-            'type': 'int', 'value': 10, 'unit': '#',
-            'lolim': 1, 'low': 1, 'lolo': 1,
-            'hilim': _ct.BIASFB_MAX_DATA_SIZE,
-            'high': _ct.BIASFB_MAX_DATA_SIZE,
-            'hihi': _ct.BIASFB_MAX_DATA_SIZE},
+            'type': 'int', 'value': 1, 'unit': '#',
+            'lolim': 1, 'hilim': _ct.BIASFB_MAX_DATA_SIZE},
         'ModelUpdateData-Sel': {
-            'type': 'enum', 'value': _ct.OffOn.Off, 'enums': _et.OFF_ON,
+            'type': 'enum', 'value': _ct.OffOn.On, 'enums': _et.OFF_ON,
             'unit': 'Off_On'},
         'ModelUpdateData-Sts': {
-            'type': 'enum', 'value': _ct.OffOn.Off, 'enums': _et.OFF_ON,
+            'type': 'enum', 'value': _ct.OffOn.On, 'enums': _et.OFF_ON,
             'unit': 'Off_On'},
         'ModelDataBias-SP': {
             'type': 'float', 'count': _ct.BIASFB_MAX_DATA_SIZE,
@@ -493,29 +471,23 @@ def get_biasfb_database():
             'value': [0]*_ct.BIASFB_MAX_DATA_SIZE, 'unit': 'mA'},
 
         'LinModAngCoeff-SP': {
-            'type': 'float', 'value': 10, 'unit': 'V/mA',
-            'prec': 2, 'lolim': 0.1, 'low': 0.1, 'lolo': 0.1,
-            'hilim': 30.0, 'high': 30.0, 'hihi': 30.0},
+            'type': 'float', 'value': 15, 'unit': 'V/mA',
+            'prec': 2, 'lolim': 0.1, 'hilim': 30.0},
         'LinModAngCoeff-RB': {
-            'type': 'float', 'value': 10, 'unit': 'V/mA',
-            'prec': 2, 'lolim': 0.1, 'low': 0.1, 'lolo': 0.1,
-            'hilim': 30.0, 'high': 30.0, 'hihi': 30.0},
+            'type': 'float', 'value': 15, 'unit': 'V/mA',
+            'prec': 2, 'lolim': 0.1, 'hilim': 30.0},
         'LinModAngCoeff-Mon': {
-            'type': 'float', 'value': 10, 'unit': 'V/mA',
-            'prec': 2, 'lolim': 0.1, 'low': 0.1, 'lolo': 0.1,
-            'hilim': 30.0, 'high': 30.0, 'hihi': 30.0},
+            'type': 'float', 'value': 15, 'unit': 'V/mA',
+            'prec': 2, 'lolim': 0.1, 'hilim': 30.0},
         'LinModOffCoeff-SP': {
             'type': 'float', 'value': -52, 'unit': 'V/mA',
-            'prec': 2, 'lolim': -120, 'low': -120, 'lolo': -120,
-            'hilim': -30.0, 'high': -30.0, 'hihi': -30.0},
+            'prec': 2, 'lolim': -120, 'hilim': -30.0},
         'LinModOffCoeff-RB': {
             'type': 'float', 'value': -52, 'unit': 'V/mA',
-            'prec': 2, 'lolim': -120, 'low': -120, 'lolo': -120,
-            'hilim': -30.0, 'high': -30.0, 'hihi': -30.0},
+            'prec': 2, 'lolim': -120, 'hilim': -30.0},
         'LinModOffCoeff-Mon': {
             'type': 'float', 'value': -52, 'unit': 'V/mA',
-            'prec': 2, 'lolim': -120, 'low': -120, 'lolo': -120,
-            'hilim': -30.0, 'high': -30.0, 'hihi': -30.0},
+            'prec': 2, 'lolim': -120, 'hilim': -30.0},
 
         # These are used to give the model inference about the bias
         # Generally ploted in Injcurr X Bias graphs
@@ -533,40 +505,31 @@ def get_biasfb_database():
 
         'GPModNoiseStd-SP': {
             'type': 'float', 'value': 0.05, 'unit': 'mA', 'prec': 4,
-            'lolim': 0.005, 'low': 0.005, 'lolo': 0.005,
-            'hilim': 0.5, 'high': 0.5, 'hihi': 0.5},
+            'lolim': 0.005, 'hilim': 0.5},
         'GPModNoiseStd-RB': {
             'type': 'float', 'value': 0.05, 'unit': 'mA', 'prec': 4,
-            'lolim': 0.005, 'low': 0.005, 'lolo': 0.005,
-            'hilim': 0.5, 'high': 0.5, 'hihi': 0.5},
+            'lolim': 0.005, 'hilim': 0.5},
         'GPModNoiseStd-Mon': {
             'type': 'float', 'value': 0.05, 'unit': 'mA', 'prec': 4,
-            'lolim': 0.005, 'low': 0.005, 'lolo': 0.005,
-            'hilim': 0.5, 'high': 0.5, 'hihi': 0.5},
+            'lolim': 0.005, 'hilim': 0.5},
         'GPModKernStd-SP': {
             'type': 'float', 'value': 0.4, 'unit': 'mA', 'prec': 3,
-            'lolim': 0.05, 'low': 0.05, 'lolo': 0.05,
-            'hilim': 1, 'high': 1, 'hihi': 1},
+            'lolim': 0.05, 'hilim': 1},
         'GPModKernStd-RB': {
             'type': 'float', 'value': 0.4, 'unit': 'mA', 'prec': 3,
-            'lolim': 0.05, 'low': 0.05, 'lolo': 0.05,
-            'hilim': 1, 'high': 1, 'hihi': 1},
+            'lolim': 0.05, 'hilim': 1},
         'GPModKernStd-Mon': {
             'type': 'float', 'value': 0.4, 'unit': 'mA', 'prec': 3,
-            'lolim': 0.05, 'low': 0.05, 'lolo': 0.05,
-            'hilim': 1, 'high': 1, 'hihi': 1},
+            'lolim': 0.05, 'hilim': 1},
         'GPModKernLenScl-SP': {
             'type': 'float', 'value': 5, 'unit': 'V', 'prec': 3,
-            'lolim': 1, 'low': 1, 'lolo': 1,
-            'hilim': 10, 'high': 10, 'hihi': 10},
+            'lolim': 1, 'hilim': 10},
         'GPModKernLenScl-RB': {
             'type': 'float', 'value': 5, 'unit': 'V', 'prec': 3,
-            'lolim': 1, 'low': 1, 'lolo': 1,
-            'hilim': 10, 'high': 10, 'hihi': 10},
+            'lolim': 1, 'hilim': 10},
         'GPModKernLenScl-Mon': {
             'type': 'float', 'value': 5, 'unit': 'V', 'prec': 3,
-            'lolim': 1, 'low': 1, 'lolo': 1,
-            'hilim': 10, 'high': 10, 'hihi': 10},
+            'lolim': 1, 'hilim': 10},
 
         # These are used to give the model inference about the bias
         # Generally ploted in Injcurr X Bias graphs

--- a/siriuspy/siriuspy/injctrl/csdev.py
+++ b/siriuspy/siriuspy/injctrl/csdev.py
@@ -254,17 +254,17 @@ def get_injctrl_propty_database():
             'type': 'enum', 'value': _ct.TopUpSts.Off, 'enums': _et.TOPUPSTS,
             'unit': 'Off_Wai_TOn_Inj_TOff_Skip'},
         'TopUpPeriod-SP': {
-            'type': 'int', 'value': 5, 'unit': 'min',
-            'lolim': 1, 'hilim': 6*60},
+            'type': 'int', 'value': 3*60, 'unit': 's',
+            'lolim': 1, 'hilim': 60*60},
         'TopUpPeriod-RB': {
-            'type': 'int', 'value': 5, 'unit': 'min',
-            'lolim': 1, 'hilim': 6*60},
+            'type': 'int', 'value': 3*60, 'unit': 's',
+            'lolim': 1, 'hilim': 60*60},
         'TopUpHeadStartTime-SP': {
             'type': 'float', 'value': 0, 'unit': 's', 'prec': 2,
-            'lolim': 0, 'hilim': 2*60},
+            'lolim': 0, 'hilim': 10},
         'TopUpHeadStartTime-RB': {
             'type': 'float', 'value': 0, 'unit': 's', 'prec': 2,
-            'lolim': 0, 'hilim': 2*60},
+            'lolim': 0, 'hilim': 10},
         'TopUpPUStandbyEnbl-Sel': {
             'type': 'enum', 'value': _ct.DsblEnbl.Dsbl,
             'enums': _et.DSBL_ENBL, 'unit': 'Dsbl_Enbl'},

--- a/siriuspy/siriuspy/injctrl/main.py
+++ b/siriuspy/siriuspy/injctrl/main.py
@@ -60,18 +60,18 @@ class App(_Callback):
         self._target_current = 100.0
         self._bucketlist_start = 1
         self._bucketlist_stop = 864
-        self._bucketlist_step = 15
+        self._bucketlist_step = 29
         self._isinj_delay = 0
         self._isinj_duration = 300
 
         self._topup_state_sel = _Const.OffOn.Off
         self._topup_state_sts = _Const.TopUpSts.Off
-        self._topup_period = 5*60  # [s]
-        self._topup_headstarttime = 0
+        self._topup_period = 4*60  # [s]
+        self._topup_headstarttime = 2.43
         self._topup_pustandbyenbl = _Const.DsblEnbl.Dsbl
         self._topup_puwarmuptime = 30
         self._topup_pu_prepared = True
-        self._topup_liwarmupenbl = _Const.DsblEnbl.Dsbl
+        self._topup_liwarmupenbl = _Const.DsblEnbl.Enbl
         self._topup_liwarmuptime = 30
         self._topup_li_prepared = True
         self._topup_bopsstandbyenbl = _Const.DsblEnbl.Dsbl

--- a/siriuspy/siriuspy/injctrl/main.py
+++ b/siriuspy/siriuspy/injctrl/main.py
@@ -731,7 +731,7 @@ class App(_Callback):
     def set_topup_headstarttime(self, value):
         """Set top-up head start time [s]."""
         # do not allow headstarttime to be larger than topup_period.
-        if not 0 <= value < self._topup_period - 1:
+        if not 0 <= value <= self._topup_period - 1:
             return False
         self._topup_headstarttime = value
         self._update_log('Changed top-up head start time to '+str(value)+'s.')


### PR DESCRIPTION
This PR changes the default values of some topup related PVs in `injctrl` IOC and changes the unit of the PV `TopUpPeriod` to seconds, allowing the user to configure topup to run in smaller time intervals. This change will be useful during accumulation, when we generally want to pulse as fast as possible, without heating the septa too much.