### PR TITLE
Add PsMtn BPM trigger to global_config.

### DIFF
--- a/siriuspy/siriuspy/clientconfigdb/types/as_diagnostics.py
+++ b/siriuspy/siriuspy/clientconfigdb/types/as_diagnostics.py
@@ -107,7 +107,7 @@ _amcfpgaevrs = [
     'IA-20RaBPM:TI-AMCFPGAEVR:',
     'IA-20RaBPMTL:TI-AMCFPGAEVR:',
     ]
-_amcfpgaevr_amcs = ['AMC3', 'AMC4', 'AMC5', 'AMC6', 'AMC7']
+_amcfpgaevr_amcs = ['AMC3', 'AMC4', 'AMC6', 'AMC7']
 _amcfpgaevr_propts = [
     ['State-Sel', 1, 0.0],
     ['Src-Sel', 3, 0.0],

--- a/siriuspy/siriuspy/clientconfigdb/types/as_diagnostics.py
+++ b/siriuspy/siriuspy/clientconfigdb/types/as_diagnostics.py
@@ -107,7 +107,7 @@ _amcfpgaevrs = [
     'IA-20RaBPM:TI-AMCFPGAEVR:',
     'IA-20RaBPMTL:TI-AMCFPGAEVR:',
     ]
-_amcfpgaevr_amcs = ['AMC2', 'AMC3', 'AMC4', 'AMC5', 'AMC6', 'AMC7']
+_amcfpgaevr_amcs = ['AMC3', 'AMC4', 'AMC5', 'AMC6', 'AMC7']
 _amcfpgaevr_propts = [
     ['State-Sel', 1, 0.0],
     ['Src-Sel', 3, 0.0],

--- a/siriuspy/siriuspy/clientconfigdb/types/global_config.py
+++ b/siriuspy/siriuspy/clientconfigdb/types/global_config.py
@@ -620,6 +620,15 @@ _pvs_as_ti = [
     ['SI-Fam:TI-BPM:DeltaDelayRaw-SP', 30*[0, ], 0],
     ['SI-Fam:TI-BPM:LowLvlLock-Sel', 0, 0.0],
 
+    ['SI-Fam:TI-BPM-PsMtn:DelayRaw-SP', 0, 0],
+    ['SI-Fam:TI-BPM-PsMtn:WidthRaw-SP', 0, 0.0],
+    ['SI-Fam:TI-BPM-PsMtn:NrPulses-SP', 0, 0.0],
+    ['SI-Fam:TI-BPM-PsMtn:Polarity-Sel', 0, 0.0],
+    ['SI-Fam:TI-BPM-PsMtn:Src-Sel', 0, 0.0],
+    ['SI-Fam:TI-BPM-PsMtn:State-Sel', 0, 0.0],
+    ['SI-Fam:TI-BPM-PsMtn:DeltaDelayRaw-SP', 30*[0, ], 0],
+    ['SI-Fam:TI-BPM-PsMtn:LowLvlLock-Sel', 0, 0.0],
+
     ['SI-Fam:TI-FOFB:DelayRaw-SP', 0, 0],
     ['SI-Fam:TI-FOFB:WidthRaw-SP', 0, 0.0],
     ['SI-Fam:TI-FOFB:NrPulses-SP', 0, 0.0],

--- a/siriuspy/siriuspy/search/hl_time_search.py
+++ b/siriuspy/siriuspy/search/hl_time_search.py
@@ -83,6 +83,7 @@ class HLTimeSearch:
 
     @classmethod
     def get_hl_from_ll_triggers(cls, channel):
+        cls._init()
         # channel = _LLSearch.get_channel_output_port_pvname(channel)
         prpt = channel.propty
         if prpt.startswith('OTP'):

--- a/siriuspy/siriuspy/timesys/ll_classes.py
+++ b/siriuspy/siriuspy/timesys/ll_classes.py
@@ -678,7 +678,7 @@ class _BASETRIG(_BaseLL):
             dic_ = {'Src': n}
         else:
             n -= offset
-            evt = int(_TIConst.EvtHL2LLMap[pname][-2:])
+            evt = int(_TIConst.EvtHL2LLMap[pname][3:])
             dic_ = {'Src': n, 'Evt': evt}
         if 'SrcTrig' in self._dict_convert_prop2pv.keys():
             intrg = _LLSearch.get_channel_internal_trigger_pvname(

--- a/siriuspy/siriuspy/timesys/ll_classes.py
+++ b/siriuspy/siriuspy/timesys/ll_classes.py
@@ -678,7 +678,7 @@ class _BASETRIG(_BaseLL):
             dic_ = {'Src': n}
         else:
             n -= offset
-            evt = int(_TIConst.EvtHL2LLMap[pname][3:])
+            evt = int(_TIConst.EvtHL2LLMap[pname].strip('Evt'))
             dic_ = {'Src': n, 'Evt': evt}
         if 'SrcTrig' in self._dict_convert_prop2pv.keys():
             intrg = _LLSearch.get_channel_internal_trigger_pvname(


### PR DESCRIPTION
This PR : 
- adds high level PsMtn BPM trigger
- fixes a bug in HLTiming IOC that was causing erroneous Evt number parsing
- removes from as_diagnostics configuration the AMCFPGAEVR PVs that are controlled by HL triggers