### PR TITLE
Remove EPU correctors from global config

### DIFF
--- a/siriuspy/siriuspy/clientconfigdb/types/global_config.py
+++ b/siriuspy/siriuspy/clientconfigdb/types/global_config.py
@@ -2595,20 +2595,8 @@ _pvs_si_ps_qn = [
 _pvs_si_ps_ids = [
     ['SI-14SB:PS-CH-1:OpMode-Sel', _SLOWREF, 0.0],
     ['SI-14SB:PS-CH-2:OpMode-Sel', _SLOWREF, 0.0],
-    ['SI-10SB:PS-CH-1:OpMode-Sel', _SLOWREF, 0.0],
-    ['SI-10SB:PS-CH-2:OpMode-Sel', _SLOWREF, 0.0],
-    ['SI-10SB:PS-CV-1:OpMode-Sel', _SLOWREF, 0.0],
-    ['SI-10SB:PS-CV-2:OpMode-Sel', _SLOWREF, 0.0],
-    ['SI-10SB:PS-QS-1:OpMode-Sel', _SLOWREF, 0.0],
-    ['SI-10SB:PS-QS-2:OpMode-Sel', _SLOWREF, 0.0],
     ['SI-14SB:PS-CH-1:Current-SP', 0.0, 0.0],  # [A]
     ['SI-14SB:PS-CH-2:Current-SP', 0.0, 0.0],  # [A]
-    ['SI-10SB:PS-CH-1:Current-SP', 0.0, 0.0],  # [A]
-    ['SI-10SB:PS-CH-2:Current-SP', 0.0, 0.0],  # [A]
-    ['SI-10SB:PS-CV-1:Current-SP', 0.0, 0.0],  # [A]
-    ['SI-10SB:PS-CV-2:Current-SP', 0.0, 0.0],  # [A]
-    ['SI-10SB:PS-QS-1:Current-SP', 0.0, 0.0],  # [A]
-    ['SI-10SB:PS-QS-2:Current-SP', 0.0, 0.0],  # [A]
     ]
 
 


### PR DESCRIPTION
Since now these correctors are used in the IDFF loop control.