### PR TITLE
Update orbit interlock device

### DIFF
--- a/siriuspy/siriuspy/devices/orbit_interlock.py
+++ b/siriuspy/siriuspy/devices/orbit_interlock.py
@@ -88,6 +88,7 @@ class BaseOrbitIntlk:
         self._oper = {
             'mean': self._mean,
             'diff': self._diff,
+            'min': min,
         }
 
     @staticmethod

--- a/siriuspy/siriuspy/diagbeam/bpm/csdev.py
+++ b/siriuspy/siriuspy/diagbeam/bpm/csdev.py
@@ -297,10 +297,10 @@ class Const(_csdev.Const):
             'MonitEnable-Sts': {
                 'type': 'enum', 'enums': Const.MonitEnbl._fields, 'value': 3},
             'MONITUpdtTime-SP': {
-                'type': 'float', 'value': 0, 'low': 0.05, 'high': 1.0,
+                'type': 'float', 'value': 0, 'low': 0.001, 'high': 1.0,
                 'unit': 's'},
             'MONITUpdtTime-RB': {
-                'type': 'float', 'value': 0, 'low': 0.05, 'high': 1.0,
+                'type': 'float', 'value': 0, 'low': 0.001, 'high': 1.0,
                 'unit': 's'},
             }
         return {prefix + k: v for k, v in dbase.items()}


### PR DESCRIPTION
Add option to calculate a minimum between downstream and upstream BPM metric