### PR TITLE
TIM.BUG: Fix length of some char array PVs.

### DIFF
--- a/siriuspy/siriuspy/timesys/csdev.py
+++ b/siriuspy/siriuspy/timesys/csdev.py
@@ -605,15 +605,17 @@ def get_hl_trigger_database(hl_trigger, prefix=''):
     dbase['InInjTable-Mon'] = {
         'type': 'enum', 'enums': _et.ININJTAB, 'value': 0}
 
+    # NOTE: we need to add plus 1 to the PVs count due to some unexpected
+    # behavior of pcaspy
     labs = '\n'.join(Const.HLTrigStatusLabels)
     dbase['StatusLabels-Cte'] = {
-        'type': 'char', 'count': len(labs), 'value': labs}
+        'type': 'char', 'count': len(labs)+1, 'value': labs}
 
     ll_trigs = '\n'.join(ll_trig_names)
     dbase['LowLvlTriggers-Cte'] = {
-        'type': 'char', 'count': len(ll_trigs), 'value': ll_trigs}
+        'type': 'char', 'count': len(ll_trigs)+1, 'value': ll_trigs}
     channels = '\n'.join(_HLTimeSearch.get_hl_trigger_channels(hl_trigger))
     dbase['CtrldChannels-Cte'] = {
-        'type': 'char', 'count': len(channels), 'value': channels}
+        'type': 'char', 'count': len(channels)+1, 'value': channels}
 
     return {prefix + pv: dt for pv, dt in dbase.items()}

--- a/siriuspy/siriuspy/timesys/csdev.py
+++ b/siriuspy/siriuspy/timesys/csdev.py
@@ -605,15 +605,15 @@ def get_hl_trigger_database(hl_trigger, prefix=''):
     dbase['InInjTable-Mon'] = {
         'type': 'enum', 'enums': _et.ININJTAB, 'value': 0}
 
+    labs = '\n'.join(Const.HLTrigStatusLabels)
     dbase['StatusLabels-Cte'] = {
-        'type': 'char', 'count': 1000,
-        'value': '\n'.join(Const.HLTrigStatusLabels)
-        }
+        'type': 'char', 'count': len(labs) + 10, 'value': labs}
+
     ll_trigs = '\n'.join(ll_trig_names)
     dbase['LowLvlTriggers-Cte'] = {
-        'type': 'char', 'count': 5000, 'value': ll_trigs}
+        'type': 'char', 'count': len(ll_trigs) + 10, 'value': ll_trigs}
     channels = '\n'.join(_HLTimeSearch.get_hl_trigger_channels(hl_trigger))
     dbase['CtrldChannels-Cte'] = {
-        'type': 'char', 'count': 5000, 'value': channels}
+        'type': 'char', 'count': len(channels) + 10, 'value': channels}
 
     return {prefix + pv: dt for pv, dt in dbase.items()}

--- a/siriuspy/siriuspy/timesys/csdev.py
+++ b/siriuspy/siriuspy/timesys/csdev.py
@@ -607,13 +607,13 @@ def get_hl_trigger_database(hl_trigger, prefix=''):
 
     labs = '\n'.join(Const.HLTrigStatusLabels)
     dbase['StatusLabels-Cte'] = {
-        'type': 'char', 'count': len(labs) + 10, 'value': labs}
+        'type': 'char', 'count': len(labs), 'value': labs}
 
     ll_trigs = '\n'.join(ll_trig_names)
     dbase['LowLvlTriggers-Cte'] = {
-        'type': 'char', 'count': len(ll_trigs) + 10, 'value': ll_trigs}
+        'type': 'char', 'count': len(ll_trigs), 'value': ll_trigs}
     channels = '\n'.join(_HLTimeSearch.get_hl_trigger_channels(hl_trigger))
     dbase['CtrldChannels-Cte'] = {
-        'type': 'char', 'count': len(channels) + 10, 'value': channels}
+        'type': 'char', 'count': len(channels), 'value': channels}
 
     return {prefix + pv: dt for pv, dt in dbase.items()}


### PR DESCRIPTION
@anacso17 informed me that some char array PVs from the high level timing IOCs were causing instabilities on the PV Gateway. She told me the problem was related to PVs whose value length exceeded the `'count'`  of the PV. Namely, the following PVs:
```
SI-Glob:TI-Mags-Corrs:CtrldChannels-Cte
SI-Glob:TI-Mags-QTrims:CtrldChannels-Cte
```

I noticed the definition of the above mentioned field was hard-coded.
I changed it to be defined according to the real length of each value.