### PR TITLE
Fix FOFB

### DIFF
--- a/siriuspy/siriuspy/devices/fofb.py
+++ b/siriuspy/siriuspy/devices/fofb.py
@@ -943,6 +943,8 @@ class FamFastCorrs(_Devices):
             raise ValueError('Values and indices must have the same size.')
         for i, dev in enumerate(devs):
             impltd = _np.hstack([dev.invrespmat_row_x, dev.invrespmat_row_y])
+            if len(values[i]) != len(impltd):
+                return False
             if not _np.allclose(values[i], impltd, atol=atol):
                 return False
         return True


### PR DESCRIPTION
Fix bug in correctors periodic checks: do not raise exception when InvRespMatRow PVs have size different from desired