### PR TITLE
Adapt Device methods naming to consensus standard

### DIFF
--- a/siriuspy/siriuspy/devices/energy.py
+++ b/siriuspy/siriuspy/devices/energy.py
@@ -35,22 +35,22 @@ class Energy(_DevicesSync):
     @property
     def energy(self):
         """Return Ref-Mon energy."""
-        return self.value_get('EnergyRef-Mon')
+        return self.get_value('EnergyRef-Mon')
 
     @energy.setter
     def energy(self, value):
         """Set energy."""
-        self.value_set('Energy-SP', value)
+        self.set_value('Energy-SP', value)
 
     @property
     def energy_sp(self):
         """Return -SP energy."""
-        return self.value_get('Energy-SP')
+        return self.get_value('Energy-SP')
 
     @property
     def energy_mon(self):
         """Return -Mon energy."""
-        return self.value_get('Energy-Mon')
+        return self.get_value('Energy-Mon')
 
     @staticmethod
     def _get_dipole_devnames(devname):

--- a/siriuspy/siriuspy/devices/psconv.py
+++ b/siriuspy/siriuspy/devices/psconv.py
@@ -38,12 +38,12 @@ class PSProperty(_DevicesSync):
     @property
     def value(self):
         """Return property value."""
-        return self.value_get(self.property_sync)
+        return self.get_value(self.property_sync)
 
     @value.setter
     def value(self, current):
         """Set property value."""
-        self.value_set(self.property_sync, current)
+        self.set_value(self.property_sync, current)
 
     @property
     def limits(self):

--- a/siriuspy/siriuspy/devices/syncd.py
+++ b/siriuspy/siriuspy/devices/syncd.py
@@ -47,7 +47,7 @@ class DevicesSync(_Device):
                 return False
         return True
 
-    def value_get(self, propty):
+    def get_value(self, propty):
         """Return property value."""
         if not self.connected:
             return
@@ -61,7 +61,7 @@ class DevicesSync(_Device):
             return
         return sum(values) / len(values)
 
-    def value_set(self, propty, value):
+    def set_value(self, propty, value):
         """Set property."""
         if not self.connected:
             return

--- a/siriuspy/siriuspy/simul/simps.py
+++ b/siriuspy/siriuspy/simul/simps.py
@@ -75,7 +75,7 @@ class SimPSTypeModel(_Simulator):
         if pvn not in self:
             # If PwrState-Sts not simulated, assume it to be On.
             return _Const.PwrStateSts.On
-        return self.pv_value_get(pvn)
+        return self.get_pv_value(pvn)
 
     @staticmethod
     def conv_psname2typemodel(psname):
@@ -136,7 +136,7 @@ class SimPSTypeModel(_Simulator):
         else:
             setpoints = dict()
             for sp_pvname in self._setpoint_pvs:
-                setpoints[sp_pvname] = self.pv_value_get(sp_pvname)
+                setpoints[sp_pvname] = self.get_pv_value(sp_pvname)
 
         # synchronize Current PVs
         for sp_pvname, sp_value in setpoints.items():

--- a/siriuspy/siriuspy/simul/simulator.py
+++ b/siriuspy/siriuspy/simul/simulator.py
@@ -98,7 +98,7 @@ class Simulator(ABC):
         """Return dict with pvnames and associated values of simulator."""
         vals = dict()
         for pvname in self._pvs:
-            vals[pvname] = self.pv_value_get(pvname)
+            vals[pvname] = self.get_pv_value(pvname)
         return vals
 
     def pv_check(self, pvname):
@@ -109,7 +109,7 @@ class Simulator(ABC):
                 return True
         return False
 
-    def pv_value_get(self, pvname):
+    def get_pv_value(self, pvname):
         """Get SimPV value without invoking simulator callback."""
         return self._pvs[pvname].get_sim()
 


### PR DESCRIPTION
You guys should have objected this standard a long time ago. It would have avoided several minutes of argument typing at this point, probably ! :) 

I also consistently used the naming `*_set(...` for methods in `pwrsupply` subpackage classes. But I dont think it is necessary to adapt non-device classes.