### PR TITLE
Fix FamBPMs

### DIFF
--- a/siriuspy/siriuspy/devices/bpm.py
+++ b/siriuspy/siriuspy/devices/bpm.py
@@ -1,13 +1,14 @@
 """BPM devices."""
 
 import time as _time
-# from threading import Event as _Flag
 
 import numpy as _np
 
-from .device import Device as _Device
 from ..diagbeam.bpm.csdev import Const as _csbpm
 from ..search import BPMSearch as _BPMSearch
+from .device import Device as _Device
+
+# from threading import Event as _Flag
 
 
 class BPM(_Device):

--- a/siriuspy/siriuspy/devices/bpm_eq.py
+++ b/siriuspy/siriuspy/devices/bpm_eq.py
@@ -252,15 +252,15 @@ class EqualizeBPMs(_FamBPMs):
 
         # acquire antennas data in FOFB rate
         self._log('Preparing BPMs')
-        ret = self.cmd_mturn_acq_abort()
+        ret = self.cmd_abort_mturn_acquisition()
         if ret > 0:
             self._log(
                 f'ERR: BPM {self.bpm_names[ret-1]} did not abort '
                 'previous acquistion.')
             return
 
-        self.mturn_reset_flags_and_update_initial_timestamps()
-        ret = self.mturn_config_acquisition(
+        self.reset_mturn_initial_state()
+        ret = self.config_mturn_acquisition(
             nr_points_after=self._acq_nrpoints, nr_points_before=0,
             acq_rate='FOFB', repeat=False, external=True)
         if ret > 0:
@@ -272,7 +272,7 @@ class EqualizeBPMs(_FamBPMs):
         self.trigger.source = self.trigger.source_options.index('Clock3')
 
         self._log('Waiting BPMs to update')
-        ret = self.mturn_wait_update(timeout=self._acq_timeout)
+        ret = self.wait_update_mturn(timeout=self._acq_timeout)
         if ret > 0:
             self._log(
                 f'ERR: BPM {self.bpm_names[ret-1]} did not update in time.')
@@ -330,7 +330,7 @@ class EqualizeBPMs(_FamBPMs):
     def _do_acquire_for_check(self):
         # acquire antennas data in FOFB rate
         self._log('Preparing BPMs')
-        ret = self.cmd_mturn_acq_abort()
+        ret = self.cmd_abort_mturn_acquisition()
         if ret > 0:
             self._log(
                 f'ERR: BPM {self.bpm_names[ret-1]} did not abort '
@@ -341,8 +341,8 @@ class EqualizeBPMs(_FamBPMs):
         fsamp = self.get_sampling_frequency(1)
         nrpts = int(fsamp / fswtc)
 
-        self.mturn_reset_flags_and_update_initial_timestamps()
-        ret = self.mturn_config_acquisition(
+        self.reset_mturn_initial_state()
+        ret = self.config_mturn_acquisition(
             nr_points_after=nrpts, nr_points_before=0,
             acq_rate='FOFB', repeat=False, external=True)
         if ret > 0:
@@ -354,7 +354,7 @@ class EqualizeBPMs(_FamBPMs):
         self.trigger.source = self.trigger.source_options.index('Clock3')
 
         self._log('Waiting BPMs to update')
-        ret = self.mturn_wait_update(timeout=self._acq_timeout)
+        ret = self.wait_update_mturn(timeout=self._acq_timeout)
         if ret > 0:
             self._log(
                 f'ERR: BPM {self.bpm_names[ret-1]} did not update in time.')
@@ -685,7 +685,7 @@ class EqualizeBPMs(_FamBPMs):
         b_d = (b-d) / (b+d)
         # Get the positions:
         posx = (a_c - b_d) / 2
-        posy = (a_c + b_d) / 2 
+        posy = (a_c + b_d) / 2
         # Apply position gains:
         posx *= gainx[:, None]
         posy *= gainy[:, None]

--- a/siriuspy/siriuspy/devices/bpm_fam.py
+++ b/siriuspy/siriuspy/devices/bpm_fam.py
@@ -1,5 +1,6 @@
 """FamBPM deviceSet."""
 
+import logging as _log
 import sys
 import time as _time
 # from threading import Event as _Flag
@@ -112,8 +113,10 @@ class FamBPMs(_DeviceSet):
                     f'\n{bpm.devname:<20s}: ' +
                     f'rb {bpm.rffe_att:.0f} != sp {value:.0f}')
 
-        print('RFFE attenuation set confirmed in all BPMs', end='')
-        print(', except:' + mstr if mstr else '.')
+        stg = ', except:' if mstr else '.'
+        _log.info('RFFE attenuation set confirmed in all BPMs%s', stg)
+        if mstr:
+            _log.info(mstr)
         return okall
 
     def get_slow_orbit(self):
@@ -192,7 +195,7 @@ class FamBPMs(_DeviceSet):
         if len(fs_bpms) == 1:
             return fs_bpms.pop()
         else:
-            print('BPMs are not configured with the same ACQChannel.')
+            _log.warning('BPMs are not configured with the same ACQChannel.')
             return None
 
     def get_switching_frequency(self, rf_freq: float) -> float:
@@ -210,7 +213,7 @@ class FamBPMs(_DeviceSet):
         if len(fsw_bpms) == 1:
             return fsw_bpms.pop()
         else:
-            print('BPMs are not configured with the same SwMode.')
+            _log.warning('BPMs are not configured with the same SwMode.')
             return None
 
     def mturn_config_acquisition(

--- a/siriuspy/siriuspy/devices/bpm_fam.py
+++ b/siriuspy/siriuspy/devices/bpm_fam.py
@@ -74,6 +74,12 @@ class FamBPMs(_DeviceSet):
             dev, auto_monitor_mon=False, ispost_mortem=ispost_mortem,
             props2init=props2init) for dev in bpm_names]
 
+        for bpm in self.bpms:
+            for sig in self.mturn_signals2acq:
+                sig = 'SUM' if sig.upper() == 'S' else sig.upper()
+                pv = bpm.pv_object(f'GEN_{sig}ArrayData')
+                pv.auto_monitor = True
+
         super().__init__(self.bpms[:], devname=devname)
         self._bpm_names = bpm_names
         self._csbpm = self.bpms[0].csdata

--- a/siriuspy/siriuspy/devices/bpm_fam.py
+++ b/siriuspy/siriuspy/devices/bpm_fam.py
@@ -441,13 +441,16 @@ class FamBPMs(_DeviceSet):
             timeout (int, optional): Waiting timeout. Defaults to 10.
 
         Returns:
-            float: code describing what happened:
+            int|float: code describing what happened:
                 -2: size of timestamps changed in relation to initial timestamp
                 -1: initial timestamps were not defined;
                 =0: data updated.
-                >0: index of the first BPM which did not update plus 1.
-                X.[1-N]: The fractional part indicates which signal, from 1 to
-                    N, that didn't update.
+                >0: timeout waiting BPMs. The returned value is a float of
+                    form X.Y, where:
+                        X: The integer part indicates the index of the first
+                            BPM which did not update plus 1.
+                        Y: The fractional part indicates which signal, from
+                            1 to N, that didn't update.
 
         """
         if self._initial_timestamps is None:
@@ -482,13 +485,16 @@ class FamBPMs(_DeviceSet):
             timeout (int, optional): Waiting timeout. Defaults to 10.
 
         Returns:
-            int: code describing what happened:
+            int|float: code describing what happened:
                 -2: size of signals changed in relation to initial signals
                 -1: initial signals were not defined;
                 =0: signals updated.
-                >0: index of the first BPM which did not update plus 1.
-                X.[1-N]: The fractional part indicates which signal, from 1 to
-                    N, that didn't update.
+                >0: timeout waiting BPMs. The returned value is a float of
+                    form X.Y, where:
+                        X: The integer part indicates the index of the first
+                            BPM which did not update plus 1.
+                        Y: The fractional part indicates which signal, from
+                            1 to N, that didn't update.
 
         """
         if self._initial_signals is None:
@@ -523,9 +529,12 @@ class FamBPMs(_DeviceSet):
                 -2: size of timestamps changed in relation to initial timestamp
                 -1: initial timestamps were not defined;
                 =0: data updated.
-                >0: index of the first BPM which did not update plus 1.
-                X.[1-N]: The fractional part indicates which signal, from 1 to
-                    N, that didn't update.
+                >0: timeout waiting BPMs. The returned value is a float of
+                    form X.Y, where:
+                        X: The integer part indicates the index of the first
+                            BPM which did not update plus 1.
+                        Y: The fractional part indicates which signal, from
+                            1 to N, that didn't update.
 
         """
         t00 = _time.time()

--- a/siriuspy/siriuspy/devices/bpm_fam.py
+++ b/siriuspy/siriuspy/devices/bpm_fam.py
@@ -498,6 +498,7 @@ class FamBPMs(_DeviceSet):
             errors = _np.all(_np.equal(sig, sig0), axis=1)
             if not _np.any(errors):
                 return 0
+            _log.debug('Signals did not update yet. Trying again.')
             _time.sleep(0.1)
             timeout -= _time.time() - t00
 

--- a/siriuspy/siriuspy/devices/bpm_fam.py
+++ b/siriuspy/siriuspy/devices/bpm_fam.py
@@ -3,31 +3,20 @@
 import logging as _log
 import sys
 import time as _time
-# from threading import Event as _Flag
-
-import numpy as _np
 from copy import deepcopy as _dcopy
 
-from .device import DeviceSet as _DeviceSet
-from ..search import BPMSearch as _BPMSearch
+import numpy as _np
+
 from ..namesys import SiriusPVName as _PVName
+from ..search import BPMSearch as _BPMSearch
 from .bpm import BPM
+from .device import DeviceSet as _DeviceSet
+
+# from threading import Event as _Flag
 
 
 class FamBPMs(_DeviceSet):
-    """Family of BPMs.
-
-    Parameters
-    ----------
-        devname (str, optional)
-            Device name. If not provided, defaults to DEVICES.SI.
-            Determine the list of BPM names.
-        bpmnames ((list, tuple), optional)
-            BPM names list. If provided, it takes priority over 'devname'
-            parameter. Defaults to None.
-        ispost_mortem (bool, optional)
-            Whether to control PM acquisition core. Defaults to False.
-    """
+    """."""
 
     TIMEOUT = 10
     RFFEATT_MAX = 30
@@ -45,7 +34,31 @@ class FamBPMs(_DeviceSet):
     def __init__(
             self, devname=None, bpmnames=None, ispost_mortem=False,
             props2init='all', mturn_signals2acq=('X', 'Y')):
-        """."""
+        """Family of BPMs.
+
+        Args:
+            devname (str, optional): Device name. If not provided, defaults to
+                DEVICES.SI. Determine the list of BPM names.
+            bpmnames ((list, tuple), optional): BPM names list. If provided,
+                it takes priority over 'devname' parameter. Defaults to None.
+            ispost_mortem (bool, optional):  Whether to control PM acquisition
+                core. Defaults to False.
+            props2init (str|list|tuple, optional): list of properties to
+                initialize in object creation. If a string is passed, it can
+                be either "all" or "acq". Defaults to "all".
+            mturn_signals2acq (str|list|tuple, optional): Which signals to
+                acquire. Signals can be defined by:
+                    X: x position;
+                    Y: y position;
+                    S: antennas sum signal;
+                    Q: skew position;
+                    A: amplitude of antenna A;
+                    B: amplitude of antenna B;
+                    C: amplitude of antenna C;
+                    D: amplitude of antenna D.
+                Defaults to "XY".
+
+        """
         if devname is None:
             devname = self.DEVICES.SI
         if devname not in self.DEVICES.ALL:

--- a/siriuspy/siriuspy/devices/bpm_fam.py
+++ b/siriuspy/siriuspy/devices/bpm_fam.py
@@ -492,7 +492,7 @@ class FamBPMs(_DeviceSet):
         sig0 = self._initial_signals
         while timeout > 0:
             t00 = _time.time()
-            sig = self.get_mturn_signals()
+            sig = _np.array(self.get_mturn_signals())
             if sig.shape != sig0.shape:
                 return -2
             errors = _np.all(_np.equal(sig, sig0), axis=1)

--- a/siriuspy/siriuspy/injctrl/bias_feedback.py
+++ b/siriuspy/siriuspy/injctrl/bias_feedback.py
@@ -1,15 +1,15 @@
 """."""
 import logging as _log
 
-from epics.ca import CAThread as _Thread
-import numpy as _np
-from numpy.polynomial import polynomial as _np_poly
 import GPy as gpy
+import numpy as _np
+from epics.ca import CAThread as _Thread
+from numpy.polynomial import polynomial as _np_poly
 
 from .csdev import Const as _Const, get_biasfb_database as _get_database
 
 
-class BiasFeedback():
+class BiasFeedback:
     """."""
 
     def __init__(self, injctrl):
@@ -17,66 +17,68 @@ class BiasFeedback():
         db_ = _get_database()
         self.database = db_
         self._injctrl = injctrl
-        self.loop_state = db_['BiasFBLoopState-Sel']['value']
+        self.loop_state = db_["BiasFBLoopState-Sel"]["value"]
         self.already_set = False
 
-        self.min_bias_voltage = db_['BiasFBMinVoltage-SP']['value']  # [V]
-        self.max_bias_voltage = db_['BiasFBMaxVoltage-SP']['value']  # [V]
+        self.min_bias_voltage = db_["BiasFBMinVoltage-SP"]["value"]  # [V]
+        self.max_bias_voltage = db_["BiasFBMaxVoltage-SP"]["value"]  # [V]
 
-        self.model_type = db_['BiasFBModelType-Sel']['value']
-        self.model_max_num_points = db_['BiasFBModelMaxNrPts-SP']['value']
-        self.model_auto_fit_rate = db_[
-            'BiasFBModelAutoFitEveryNrPts-SP']['value']
-        self.model_auto_fit = db_['BiasFBModelAutoFitParams-Sel']['value']
-        self.model_update_data = db_['BiasFBModelUpdateData-Sel']['value']
+        self.model_type = db_["BiasFBModelType-Sel"]["value"]
+        self.model_max_num_points = db_["BiasFBModelMaxNrPts-SP"]["value"]
+        self.model_auto_fit_rate = db_["BiasFBModelAutoFitEveryNrPts-SP"][
+            "value"
+        ]
+        self.model_auto_fit = db_["BiasFBModelAutoFitParams-Sel"]["value"]
+        self.model_update_data = db_["BiasFBModelUpdateData-Sel"]["value"]
 
-        self.linmodel_angcoeff = db_[
-            'BiasFBLinModAngCoeff-SP']['value']  # [V/mA]
-        self.linmodel_offcoeff = db_[
-            'BiasFBLinModOffCoeff-SP']['value']  # [V]
+        # [V/mA]:
+        self.linmodel_angcoeff = db_["BiasFBLinModAngCoeff-SP"]["value"]
+        self.linmodel_offcoeff = db_["BiasFBLinModOffCoeff-SP"]["value"]  # [V]
 
         self._npts_after_fit = 0
 
         self.bias_data = _np.array(
-            db_['BiasFBModelDataBias-Mon']['value'], dtype=float)
+            db_["BiasFBModelDataBias-Mon"]["value"], dtype=float
+        )
         self.injc_data = _np.array(
-            db_['BiasFBModelDataInjCurr-Mon']['value'], dtype=float)
+            db_["BiasFBModelDataInjCurr-Mon"]["value"], dtype=float
+        )
         self.gpmodel = None
         self._initialize_models()
 
         self.do_update_models = False
-        pv_ = self._injctrl.currinfo_dev.pv_object('InjCurr-Mon')
+        pv_ = self._injctrl.currinfo_dev.pv_object("InjCurr-Mon")
         pv_.auto_monitor = True
         pv_.add_callback(self._callback_to_thread)
 
         # pvname to write method map
         self.map_pv2write = {
-            'LoopState-Sel': self.set_loop_state,
-            'MinVoltage-SP': self.set_min_voltage,
-            'MaxVoltage-SP': self.set_max_voltage,
-            'ModelType-Sel': self.set_model_type,
-            'ModelMaxNrPts-SP': self.set_max_num_pts,
-            'ModelFitParamsNow-Cmd': self.cmd_fit_params,
-            'ModelAutoFitParams-Sel': self.set_auto_fit,
-            'ModelAutoFitEveryNrPts-SP': self.set_auto_fit_rate,
-            'ModelUpdateData-Sel': self.set_update_data,
-            'ModelDataBias-SP': self.set_data_bias,
-            'ModelDataInjCurr-SP': self.set_data_injcurr,
-            'LinModAngCoeff-SP': self.set_lin_ang_coeff,
-            'LinModOffCoeff-SP': self.set_lin_off_coeff,
-            'GPModNoiseStd-SP': self.set_gp_noise_std,
-            'GPModKernStd-SP': self.set_gp_kern_std,
-            'GPModKernLenScl-SP': self.set_gp_kern_leng,
-            'GPModNoiseStdFit-Sel': self.set_gp_noise_std_fit,
-            'GPModKernStdFit-Sel': self.set_gp_kern_std_fit,
-            'GPModKernLenSclFit-Sel': self.set_gp_kern_leng_fit,
-            }
+            "LoopState-Sel": self.set_loop_state,
+            "MinVoltage-SP": self.set_min_voltage,
+            "MaxVoltage-SP": self.set_max_voltage,
+            "ModelType-Sel": self.set_model_type,
+            "ModelMaxNrPts-SP": self.set_max_num_pts,
+            "ModelFitParamsNow-Cmd": self.cmd_fit_params,
+            "ModelAutoFitParams-Sel": self.set_auto_fit,
+            "ModelAutoFitEveryNrPts-SP": self.set_auto_fit_rate,
+            "ModelUpdateData-Sel": self.set_update_data,
+            "ModelDataBias-SP": self.set_data_bias,
+            "ModelDataInjCurr-SP": self.set_data_injcurr,
+            "LinModAngCoeff-SP": self.set_lin_ang_coeff,
+            "LinModOffCoeff-SP": self.set_lin_off_coeff,
+            "GPModNoiseStd-SP": self.set_gp_noise_std,
+            "GPModKernStd-SP": self.set_gp_kern_std,
+            "GPModKernLenScl-SP": self.set_gp_kern_leng,
+            "GPModNoiseStdFit-Sel": self.set_gp_noise_std_fit,
+            "GPModKernStdFit-Sel": self.set_gp_kern_std_fit,
+            "GPModKernLenSclFit-Sel": self.set_gp_kern_leng_fit,
+        }
 
     def init_database(self):
         """Set initial PV values."""
         for key, pvdbase in self.database.items():
             pvname = key.split(_Const.BIASFB_PROPTY_PREFIX)[1]
-            self.run_callbacks(pvname, pvdbase['value'])
+            self.run_callbacks(pvname, pvdbase["value"])
 
     @property
     def use_gpmodel(self):
@@ -95,13 +97,14 @@ class BiasFeedback():
         """."""
         ang = self.linmodel_angcoeff
         off = self.linmodel_offcoeff
-        return (-off/ang, 1/ang)
+        return (-off / ang, 1 / ang)
 
     def get_delta_current_per_pulse(
-            self, per=1, nrpul=1, curr_avg=100, curr_now=99.5, ltime=17*3600):
+        self, per=1, nrpul=1, curr_avg=100, curr_now=99.5, ltime=17 * 3600
+    ):
         """."""
         ltime = max(_Const.BIASFB_MINIMUM_LIFETIME, ltime)
-        curr_tar = curr_avg / (1 - per/2/ltime)
+        curr_tar = curr_avg / (1 - per / 2 / ltime)
         dcurr = (curr_tar - curr_now) / nrpul
         return dcurr
 
@@ -118,67 +121,68 @@ class BiasFeedback():
         if self._injctrl.has_callbacks:
             self._injctrl.run_callbacks(name, *args, **kwd)
             return
-        self.database[name]['value'] = args[0]
+        self.database[name]["value"] = args[0]
 
     def update_log(self, msg):
         """."""
-        self._injctrl.run_callbacks('Log-Mon', msg)
+        self._injctrl.run_callbacks("Log-Mon", msg)
 
     # ###################### Setter methods for IOC ######################
     def set_loop_state(self, value):
         """."""
         self.loop_state = bool(value)
-        self.run_callbacks('LoopState-Sts', value)
+        self.run_callbacks("LoopState-Sts", value)
         return True
 
     def set_min_voltage(self, value):
         """."""
         self.min_bias_voltage = value
         self._update_models()
-        self.run_callbacks('MinVoltage-RB', value)
+        self.run_callbacks("MinVoltage-RB", value)
         return True
 
     def set_max_voltage(self, value):
         """."""
         self.max_bias_voltage = value
         self._update_models()
-        self.run_callbacks('MaxVoltage-RB', value)
+        self.run_callbacks("MaxVoltage-RB", value)
         return True
 
     def set_model_type(self, value):
         """."""
         self.model_type = value
-        self.run_callbacks('ModelType-Sts', value)
+        self.run_callbacks("ModelType-Sts", value)
         return True
 
     def set_max_num_pts(self, value):
         """."""
         self.model_max_num_points = int(value)
         self._update_models()
-        self.run_callbacks('ModelMaxNrPts-RB', value)
+        self.run_callbacks("ModelMaxNrPts-RB", value)
         return True
 
     def cmd_fit_params(self, value):
         """."""
+        _ = value
         self._update_models(force_optimize=True)
         return True
 
     def set_auto_fit(self, value):
         """."""
         self.model_auto_fit = bool(value)
-        self.run_callbacks('ModelAutoFitParams-Sts', value)
+        self.run_callbacks("ModelAutoFitParams-Sts", value)
         return True
 
     def set_auto_fit_rate(self, value):
         """."""
         self.model_auto_fit_rate = int(value)
-        self.run_callbacks('ModelAutoFitEveryNrPts-RB', value)
+        self.run_callbacks("ModelAutoFitEveryNrPts-RB", value)
         return True
 
     def set_update_data(self, value):
         """."""
         self.model_update_data = bool(value)
-        self.run_callbacks('ModelUpdateData-Sts', value)
+        self.run_callbacks("ModelUpdateData-Sts", value)
         return True
 
     def set_data_bias(self, value):
@@ -186,13 +190,13 @@ class BiasFeedback():
         self.bias_data = _np.array(value)
         max_ = _Const.BIASFB_MAX_DATA_SIZE
         if self.bias_data.size > max_:
-            msg = f'WARN: Bias data is too big (>{max_:d}). '
-            msg += 'Trimming first points.'
+            msg = f"WARN: Bias data is too big (>{max_:d}). "
+            msg += "Trimming first points."
             _log.warning(msg)
             self.update_log(msg)
             self.bias_data = self.bias_data[-max_:]
         self._update_models()
-        self.run_callbacks('ModelDataBias-RB', value)
+        self.run_callbacks("ModelDataBias-RB", value)
         return True
 
     def set_data_injcurr(self, value):
@@ -200,48 +204,48 @@ class BiasFeedback():
         self.injc_data = _np.array(value)
         max_ = _Const.BIASFB_MAX_DATA_SIZE
         if self.injc_data.size > max_:
-            msg = f'WARN: InjCurr data is too big (>{max_:d}). '
-            msg += 'Trimming first points.'
+            msg = f"WARN: InjCurr data is too big (>{max_:d}). "
+            msg += "Trimming first points."
             _log.warning(msg)
             self.update_log(msg)
             self.injc_data = self.injc_data[-max_:]
         self._update_models()
-        self.run_callbacks('ModelDataInjCurr-RB', value)
+        self.run_callbacks("ModelDataInjCurr-RB", value)
         return True
 
     def set_lin_ang_coeff(self, value):
         """."""
         self.linmodel_angcoeff = value
         self._update_models()
-        self.run_callbacks('LinModAngCoeff-RB', value)
+        self.run_callbacks("LinModAngCoeff-RB", value)
         return True
 
     def set_lin_off_coeff(self, value):
         """."""
         self.linmodel_offcoeff = value
         self._update_models()
-        self.run_callbacks('LinModOffCoeff-RB', value)
+        self.run_callbacks("LinModOffCoeff-RB", value)
         return True
 
     def set_gp_noise_std(self, value):
         """."""
         self.gpmodel.likelihood.variance = value**2
         self._update_models()
-        self.run_callbacks('GPModNoiseStd-RB', value)
+        self.run_callbacks("GPModNoiseStd-RB", value)
         return True
 
     def set_gp_kern_std(self, value):
         """."""
         self.gpmodel.kern.variance = value**2
         self._update_models()
-        self.run_callbacks('GPModKernStd-RB', value)
+        self.run_callbacks("GPModKernStd-RB", value)
         return True
 
     def set_gp_kern_leng(self, value):
         """."""
         self.gpmodel.kern.lengthscale = value
         self._update_models()
-        self.run_callbacks('GPModKernLenScl-RB', value)
+        self.run_callbacks("GPModKernLenScl-RB", value)
         return True
 
     def set_gp_noise_std_fit(self, value):
@@ -250,7 +254,7 @@ class BiasFeedback():
             self.gpmodel.likelihood.variance.unfix()
         else:
             self.gpmodel.likelihood.variance.fix()
-        self.run_callbacks('GPModNoiseStdFit-Sts', value)
+        self.run_callbacks("GPModNoiseStdFit-Sts", value)
         return True
 
     def set_gp_kern_std_fit(self, value):
@@ -259,7 +263,7 @@ class BiasFeedback():
             self.gpmodel.kern.variance.unfix()
         else:
             self.gpmodel.kern.variance.fix()
-        self.run_callbacks('GPModKernStdFit-Sts', value)
+        self.run_callbacks("GPModKernStdFit-Sts", value)
         return True
 
     def set_gp_kern_leng_fit(self, value):
@@ -268,7 +272,7 @@ class BiasFeedback():
             self.gpmodel.kern.lengthscale.unfix()
         else:
             self.gpmodel.kern.lengthscale.fix()
-        self.run_callbacks('GPModKernLenSclFit-Sts', value)
+        self.run_callbacks("GPModKernLenSclFit-Sts", value)
         return True
 
     # ############ Auxiliary Methods ############
@@ -282,37 +286,40 @@ class BiasFeedback():
         self.bias_data = _np.linspace(
             self.min_bias_voltage,
             self.max_bias_voltage,
-            self.model_max_num_points)
+            self.model_max_num_points,
+        )
 
         self.injc_data = _np_poly.polyval(
-            self.bias_data, self.linmodel_coeffs_inverse)
+            self.bias_data, self.linmodel_coeffs_inverse
+        )
 
         x = self.bias_data[:, None].copy()
         y = self.injc_data[:, None].copy()
 
         kernel = gpy.kern.RBF(input_dim=1)
-        db_ = self.database['BiasFBGPModKernStd-RB']
-        kernel.variance.constrain_bounded(db_['lolim']**2, db_['hilim']**2)
-        kernel.variance = db_['value']**2
-        if bool(self.database['BiasFBGPModKernStdFit-Sts']['value']):
+        db_ = self.database["BiasFBGPModKernStd-RB"]
+        kernel.variance.constrain_bounded(db_["lolim"] ** 2, db_["hilim"] ** 2)
+        kernel.variance = db_["value"] ** 2
+        if bool(self.database["BiasFBGPModKernStdFit-Sts"]["value"]):
             kernel.variance.unfix()
         else:
             kernel.variance.fix()
 
-        db_ = self.database['BiasFBGPModKernLenScl-RB']
-        kernel.lengthscale.constrain_bounded(db_['lolim'], db_['hilim'])
-        kernel.lengthscale = db_['value']
-        if bool(self.database['BiasFBGPModKernLenSclFit-Sts']['value']):
+        db_ = self.database["BiasFBGPModKernLenScl-RB"]
+        kernel.lengthscale.constrain_bounded(db_["lolim"], db_["hilim"])
+        kernel.lengthscale = db_["value"]
+        if bool(self.database["BiasFBGPModKernLenSclFit-Sts"]["value"]):
             kernel.lengthscale.unfix()
         else:
             kernel.lengthscale.fix()
 
         gpmodel = gpy.models.GPRegression(x, y, kernel)
-        db_ = self.database['BiasFBGPModNoiseStd-RB']
+        db_ = self.database["BiasFBGPModNoiseStd-RB"]
         gpmodel.likelihood.variance.constrain_bounded(
-            db_['lolim']**2, db_['hilim']**2)
-        gpmodel.likelihood.variance = db_['value']**2
-        if bool(self.database['BiasFBGPModNoiseStdFit-Sts']['value']):
+            db_["lolim"] ** 2, db_["hilim"] ** 2
+        )
+        gpmodel.likelihood.variance = db_["value"] ** 2
+        if bool(self.database["BiasFBGPModNoiseStdFit-Sts"]["value"]):
             gpmodel.likelihood.variance.unfix()
         else:
             gpmodel.likelihood.variance.fix()
@@ -322,7 +329,7 @@ class BiasFeedback():
 
     def _update_data(self, **kwgs):
         bias = self._injctrl.egun_dev.bias.voltage
-        dcurr = kwgs['value']
+        dcurr = kwgs["value"]
         if None in {bias, dcurr}:
             return
 
@@ -331,8 +338,8 @@ class BiasFeedback():
         if bias in xun:
             idx = (xun == bias).nonzero()[0][0]
             if cnts[idx] >= max(2, self.bias_data.size // 5):
-                msg = 'WARN: Too many data with this abscissa. '
-                msg += 'Discarding point.'
+                msg = "WARN: Too many data with this abscissa. "
+                msg += "Discarding point."
                 _log.warning(msg)
                 self.update_log(msg)
                 return
@@ -341,19 +348,19 @@ class BiasFeedback():
         # Update models data
         self.bias_data = _np.r_[self.bias_data, bias]
         self.injc_data = _np.r_[self.injc_data, dcurr]
-        self.bias_data = self.bias_data[-_Const.BIASFB_MAX_DATA_SIZE:]
-        self.injc_data = self.injc_data[-_Const.BIASFB_MAX_DATA_SIZE:]
+        self.bias_data = self.bias_data[-_Const.BIASFB_MAX_DATA_SIZE :]
+        self.injc_data = self.injc_data[-_Const.BIASFB_MAX_DATA_SIZE :]
         self._update_models()
 
     def _update_models(self, force_optimize=False):
         x = _np.r_[self.bias_data, self.linmodel_offcoeff]
         y = _np.r_[self.injc_data, 0]
-        x = x[-self.model_max_num_points:]
-        y = y[-self.model_max_num_points:]
+        x = x[-self.model_max_num_points :]
+        y = y[-self.model_max_num_points :]
         if x.size != y.size:
-            msg = 'WARN: Arrays with incompatible sizes. '
-            msg += 'Trimming first points of '
-            msg += 'bias.' if x.size > y.size else 'injcurr.'
+            msg = "WARN: Arrays with incompatible sizes. "
+            msg += "Trimming first points of "
+            msg += "bias." if x.size > y.size else "injcurr."
             _log.warning(msg)
             self.update_log(msg)
             siz = min(x.size, y.size)
@@ -361,8 +368,8 @@ class BiasFeedback():
             y = y[-siz:]
 
         if x.size < 2:
-            msg = 'ERR: Too few data points. '
-            msg += 'Skipping Model update.'
+            msg = "ERR: Too few data points. "
+            msg += "Skipping Model update."
             _log.error(msg)
             self.update_log(msg)
             return
@@ -375,7 +382,8 @@ class BiasFeedback():
         # Optimize Linear Model
         if do_opt and not self.use_gpmodel:
             self.linmodel_angcoeff = _np_poly.polyfit(
-                y, x - self.linmodel_offcoeff, deg=[1, ])[1]
+                y, x - self.linmodel_offcoeff, deg=[1]
+            )[1]
             self._npts_after_fit = 0
 
         # update Gaussian Process Model data
@@ -388,39 +396,40 @@ class BiasFeedback():
             self.gpmodel.optimize_restarts(num_restarts=2, verbose=False)
             self._npts_after_fit = 0
 
-        self.run_callbacks('ModelNrPtsAfterFit-Mon', self._npts_after_fit)
+        self.run_callbacks("ModelNrPtsAfterFit-Mon", self._npts_after_fit)
         self._update_predictions()
 
     def _update_predictions(self):
         gp_ = self.gpmodel
         self.run_callbacks(
-            'GPModNoiseStd-Mon', float(gp_.likelihood.variance)**0.5)
-        self.run_callbacks('GPModKernStd-Mon', float(gp_.kern.variance)**0.5)
-        self.run_callbacks('GPModKernLenScl-Mon', float(gp_.kern.lengthscale))
-        self.run_callbacks('LinModAngCoeff-Mon', self.linmodel_angcoeff)
-        self.run_callbacks('LinModOffCoeff-Mon', self.linmodel_offcoeff)
+            "GPModNoiseStd-Mon", float(gp_.likelihood.variance) ** 0.5
+        )
+        self.run_callbacks("GPModKernStd-Mon", float(gp_.kern.variance) ** 0.5)
+        self.run_callbacks("GPModKernLenScl-Mon", float(gp_.kern.lengthscale))
+        self.run_callbacks("LinModAngCoeff-Mon", self.linmodel_angcoeff)
+        self.run_callbacks("LinModOffCoeff-Mon", self.linmodel_offcoeff)
 
-        self.run_callbacks('ModelDataBias-Mon', self.gpmodel.X.ravel())
-        self.run_callbacks('ModelDataInjCurr-Mon', self.gpmodel.Y.ravel())
-        self.run_callbacks('ModelNrPts-Mon', self.gpmodel.Y.size)
+        self.run_callbacks("ModelDataBias-Mon", self.gpmodel.X.ravel())
+        self.run_callbacks("ModelDataInjCurr-Mon", self.gpmodel.Y.ravel())
+        self.run_callbacks("ModelNrPts-Mon", self.gpmodel.Y.size)
 
         injcurr = _np.linspace(0, 1, 100)
         bias_lin = self._get_bias_voltage_linear_model(injcurr)
         bias_gp = self._get_bias_voltage_gpmodel(injcurr)
-        self.run_callbacks('LinModInferenceInjCurr-Mon', injcurr)
-        self.run_callbacks('LinModInferenceBias-Mon', bias_lin)
-        self.run_callbacks('GPModInferenceInjCurr-Mon', injcurr)
-        self.run_callbacks('GPModInferenceBias-Mon', bias_gp)
+        self.run_callbacks("LinModInferenceInjCurr-Mon", injcurr)
+        self.run_callbacks("LinModInferenceBias-Mon", bias_lin)
+        self.run_callbacks("GPModInferenceInjCurr-Mon", injcurr)
+        self.run_callbacks("GPModInferenceBias-Mon", bias_gp)
 
         bias = _np.linspace(self.min_bias_voltage, self.max_bias_voltage, 100)
         injc_lin = _np_poly.polyval(bias, self.linmodel_coeffs_inverse)
         injca_gp, injcs_gp = self._gpmodel_predict(bias)
         injcs_gp = _np.sqrt(injcs_gp)
-        self.run_callbacks('LinModPredBias-Mon', bias)
-        self.run_callbacks('LinModPredInjCurrAvg-Mon', injc_lin)
-        self.run_callbacks('GPModPredBias-Mon', bias)
-        self.run_callbacks('GPModPredInjCurrAvg-Mon', injca_gp.ravel())
-        self.run_callbacks('GPModPredInjCurrStd-Mon', injcs_gp.ravel())
+        self.run_callbacks("LinModPredBias-Mon", bias)
+        self.run_callbacks("LinModPredInjCurrAvg-Mon", injc_lin)
+        self.run_callbacks("GPModPredBias-Mon", bias)
+        self.run_callbacks("GPModPredInjCurrAvg-Mon", injca_gp.ravel())
+        self.run_callbacks("GPModPredInjCurrStd-Mon", injcs_gp.ravel())
 
     def _get_bias_voltage_gpmodel(self, dcurr):
         bias = self._gpmodel_infer_newx(_np.array(dcurr, ndmin=1))

--- a/siriuspy/siriuspy/orbintlk/main.py
+++ b/siriuspy/siriuspy/orbintlk/main.py
@@ -864,12 +864,12 @@ class App(_Callback):
 
     def _acq_config(self):
         self._update_log('Aborting BPM acquisition...')
-        ret = self._fambpm_dev.cmd_mturn_acq_abort()
+        ret = self._fambpm_dev.cmd_abort_mturn_acquisition()
         if ret > 0:
             self._update_log('ERR:Failed to abort BPM acquisition.')
             return
         self._update_log('...done. Configuring BPM acquisition...')
-        ret = self._fambpm_dev.mturn_config_acquisition(
+        ret = self._fambpm_dev.config_mturn_acquisition(
             nr_points_before=self._acq_spre,
             nr_points_after=self._acq_spost,
             acq_rate=self._acq_chan,


### PR DESCRIPTION
 - Standardize method names.
 - Add method to check if data updated in triggered acquisitions. We noted in some AC ORM measurements that only checking for the timestamps was not enough.