### PR TITLE
Add manual annotation for January 18th power grid failure in MacReport

### DIFF
--- a/siriuspy/siriuspy/machshift/macreport.py
+++ b/siriuspy/siriuspy/machshift/macreport.py
@@ -258,6 +258,7 @@ class MacReport:
         [_Time(2023, 3, 3, 22, 56, 0, 0), _Time(2023, 3, 3, 23, 0, 0, 0)],
         # power grid failure, archiver was down
         [_Time(2023, 5, 18, 5, 55, 0, 0), _Time(2023, 5, 18, 9, 8, 0, 0)],
+        [_Time(2024, 1, 18, 14, 0, 0, 0), _Time(2024, 1, 18, 19, 45, 0, 0)],
     ]
 
     def __init__(self, connector=None, logger=None):


### PR DESCRIPTION
- Add a new item in MacReport.FAILURES_MANUAL for registering archiver appliance failure related to power grid failure at January 18th