### PR TITLE
Update orbit interlock IOC for new RF configurations

### DIFF
--- a/siriuspy/siriuspy/devices/rf.py
+++ b/siriuspy/siriuspy/devices/rf.py
@@ -566,6 +566,12 @@ class RFGen(_Device):
 class ASLLRF(_Device):
     """AS LLRF."""
 
+    PROPERTIES_INTERLOCK = (
+        'FIMOrbitIntlk-Sel', 'FIMOrbitIntlk-Sts', 'IntlkAll-Mon',
+        'FIMManual-Sel', 'FIMManual-Sts',
+        'IntlkManual-Sel', 'IntlkManual-Sts', 'IntlkReset-Cmd',
+    )
+
     VoltIncRates = _get_namedtuple('VoltIncRates', (
         'vel_0p01', 'vel_0p03', 'vel_0p1', 'vel_0p25', 'vel_0p5', 'vel_1p0',
         'vel_2p0', 'vel_4p0', 'vel_6p0', 'vel_8p0', 'vel_10p0', 'vel_15p0',
@@ -611,12 +617,7 @@ class ASLLRF(_Device):
 class _BaseLLRF(_Device):
     """Base LLRF."""
 
-    PROPERTIES_INTERLOCK = (
-        'FIMOrbitIntlk-Sel', 'FIMOrbitIntlk-Sts', 'IntlkAll-Mon',
-        'FIMManual-Sel', 'FIMManual-Sts',
-        'IntlkManual-Sel', 'IntlkManual-Sts', 'IntlkReset-Cmd',
-    )
-    PROPERTIES_DEFAULT = PROPERTIES_INTERLOCK + (
+    PROPERTIES_DEFAULT = ASLLRF.PROPERTIES_INTERLOCK + (
         'SL-Sel', 'SL-Sts',
         'PLRef-RB', 'PLRef-SP', 'SLRefPhs-Mon', 'SLInpPhs-Mon',
         'ALRef-SP', 'ALRef-RB', 'SLRefAmp-Mon', 'SLInpAmp-Mon',

--- a/siriuspy/siriuspy/orbintlk/csdev.py
+++ b/siriuspy/siriuspy/orbintlk/csdev.py
@@ -127,7 +127,9 @@ class Const(_csdev.Const):
         ('TRIGGER_PM14RcvInSel-SP', 2),
     )
     REDUNDANCY_TABLE = {
+        'IA-08RaBPM:TI-AMCFPGAEVR': 'IA-08RaBPM:TI-EVR',
         'IA-10RaBPM:TI-AMCFPGAEVR': 'IA-10RaBPM:TI-EVR',
+        'IA-14RaBPM:TI-AMCFPGAEVR': 'IA-14RaDiag03:TI-EVE',
     }
 
     __EVG_CONFIGS = None

--- a/siriuspy/siriuspy/orbintlk/main.py
+++ b/siriuspy/siriuspy/orbintlk/main.py
@@ -233,13 +233,8 @@ class App(_Callback):
             pvo.connection_callbacks.append(self._conn_callback_afcphystrigs)
 
         # # RF devices
-        self._llrf = _ASLLRF(
-            devname=_ASLLRF.DEVICES.SI,
-            props2init=[
-                'ILK:BEAM:TRIP:S', 'ILK:BEAM:TRIP', 'FASTINLK-MON',
-                'ILK:MAN:S', 'ILK:MAN', 'IntlkSet-Cmd', 'Reset-Cmd',
-            ])
-        self._llrf.pv_object('FASTINLK-MON').auto_monitor = True
+        names = [_ASLLRF.DEVICES.SIA, _ASLLRF.DEVICES.SIB]
+        self._llrfs = self._create_llrfs(names)
 
         # # auxiliary devices
         self._fofb = _FOFB(
@@ -290,6 +285,14 @@ class App(_Callback):
             is_cathread=True)
         self.thread_check_configs.pause()
         self.thread_check_configs.start()
+
+    def _create_llrfs(self, names):
+        """."""
+        props_itlk = _ASLLRF.PROPERTIES_INTERLOCK
+        devs = [_ASLLRF(devname=name, props2init=props_itlk) for name in names]
+        for dev in devs:
+            dev.pv_object('IntlkAll-Mon').auto_monitor = True
+        return devs
 
     def init_database(self):
         """Set initial PV values."""
@@ -366,7 +369,8 @@ class App(_Callback):
         self._handle_lock_fouts(init)
         self._handle_lock_afcti(init)
         self._handle_lock_hltriggers(init)
-        self._handle_lock_llrf(init)
+        for dev in self._llrfs:
+            self._handle_lock_llrf(dev, init)
         self._handle_lock_bpm_configs(init)
         self._handle_lock_afcphytrigs(init)
         if init:
@@ -425,21 +429,23 @@ class App(_Callback):
                 pvo = trigdev.pv_object(prop_rb)
                 if init:
                     pvo.add_callback(
-                        _part(self._callback_lock, trigdev, prop_sp, desired_val))
+                        _part(
+                            self._callback_lock,
+                            trigdev, prop_sp, desired_val))
                 else:
                     pvo.run_callbacks()
 
-    def _handle_lock_llrf(self, init=False):
-        self._llrf.wait_for_connection(timeout=self._const.DEF_TIMEOUT)
-        pvo_beamtrip = self._llrf.pv_object('ILK:BEAM:TRIP')
-        pvo_manintlk = self._llrf.pv_object('ILK:MAN')
+    def _handle_lock_llrf(self, dev, init=False):
+        dev.wait_for_connection(timeout=self._const.DEF_TIMEOUT)
+        pvo_beamtrip = dev.pv_object('FIMOrbitIntlk-Sts')
+        pvo_manintlk = dev.pv_object('FIMManual-Sts')
         if init:
             pvo_beamtrip.add_callback(_part(
-                self._callback_lock, self._llrf,
-                'ILK:BEAM:TRIP:S', self._llrf_intlk_state))
+                self._callback_lock, dev,
+                'FIMOrbitIntlk-Sel', self._llrf_intlk_state))
             pvo_manintlk.add_callback(_part(
-                self._callback_lock, self._llrf,
-                'ILK:MAN:S', self._llrf_intlk_state))
+                self._callback_lock, dev,
+                'FIMManual-Sel', self._llrf_intlk_state))
         else:
             pvo_beamtrip.run_callbacks()
             pvo_manintlk.run_callbacks()
@@ -953,11 +959,13 @@ class App(_Callback):
     def cmd_config_llrf(self, value):
         """Configure LLRF interlock according to lock configurations."""
         _ = value
-        if not self._llrf.connected:
-            self._update_log(f'ERR:LLRF disconnected.')
-            return False
-        self._llrf['ILK:BEAM:TRIP:S'] = self._llrf_intlk_state
-        self._llrf['ILK:MAN:S'] = self._llrf_intlk_state
+        for llrf in self._llrfs:
+            if not llrf.connected:
+                name = llrf.system_nickname
+                self._update_log(f'ERR:LLRF-{name} disconnected.')
+                return False
+            llrf.fast_interlock_monitor_orbit = self._llrf_intlk_state
+            llrf.fast_interlock_monitor_manual = self._llrf_intlk_state
         return True
 
     def cmd_config_bpms(self, value):
@@ -1226,13 +1234,15 @@ class App(_Callback):
 
         # LLRF Status
         value = (1 << 2) - 1
-        dev = self._llrf
-        if dev.connected:
-            value = _updt_bit(value, 0, 0)
-            okc = dev['ILK:BEAM:TRIP'] == self._llrf_intlk_state
-            okc &= dev['ILK:MAN'] == self._llrf_intlk_state
-            value = _updt_bit(value, 1, not okc)
-        self.run_callbacks('LLRFStatus-Mon', value)
+        for dev in self._llrfs:
+            if dev.connected:
+                value = _updt_bit(value, 0, 0)
+                fim_orbit = dev.fast_interlock_monitor_orbit
+                fim_manual = dev.fast_interlock_monitor_manual
+                okc = fim_orbit == self._llrf_intlk_state
+                okc &= fim_manual == self._llrf_intlk_state
+                value = _updt_bit(value, 1, not okc)
+            self.run_callbacks('LLRFStatus-Mon', value)
 
         # check time elapsed
         ttook = _time.time() - _t0
@@ -1416,8 +1426,12 @@ class App(_Callback):
             self._update_log('ERR:EVG did not propagate event Intlk')
             # reset BPM orbit interlock, once EVG callback was not triggered
             self.cmd_reset('bpm_all')
-        if not self._llrf['FASTINLK-MON'] & (1 << 12):
-            self._update_log('ERR:LLRF did not received RFKill event')
+
+        for llrf in self._llrfs:
+            if not llrf.interlock_mon & (1 << 12):
+                name = llrf.system_nickname
+                self._update_log(
+                    f'ERR:LLRF-{name} did not receive RFKill event')
 
     def _get_bpm_rates_factor(self):
         if self._monitsum2intlksum_factor:
@@ -1481,15 +1495,22 @@ class App(_Callback):
             return
         # send soft interlock to RF
         self._update_log('FATAL:sending soft interlock to LLRF.')
-        self._llrf['IntlkSet-Cmd'] = 1
+        # sending interlock for all LLRFs systems, then wait
+        for llrf in self._llrfs:
+            llrf.interlock_manual = 1
         _time.sleep(1)
-        self._llrf['IntlkSet-Cmd'] = 0
+        for llrf in self._llrfs:
+            llrf.interlock_manual = 0
+
         if self._is_dry_run:
             # wait a little and rearming FDL acquisition
             _time.sleep(self._const.DEF_TIME2WAIT_INTLKREARM)
-            self._llrf['Reset-Cmd'] = 1
+            # sending interlock for all LLRFs systems, then wait
+            for llrf in self._llrfs:
+                llrf.interlock_reset = 1
             _time.sleep(1)
-            self._llrf['Reset-Cmd'] = 0
+            for llrf in self._llrfs:
+                llrf.interlock_reset = 0
 
     # --- device lock methods ---
 
@@ -1590,10 +1611,7 @@ class App(_Callback):
             return
 
         # else, apply value as desired
-        if device == self._llrf:
-            propty_rb = propty_sp.replace(':S', '')
-        else:
-            propty_rb = _PVName.from_sp2rb(propty_sp)
+        propty_rb = _PVName.from_sp2rb(propty_sp)
         self._update_log(f'WARN:Locking {pvname}')
         device[propty_sp] = desired_value
 

--- a/siriuspy/siriuspy/orbintlk/main.py
+++ b/siriuspy/siriuspy/orbintlk/main.py
@@ -1505,7 +1505,7 @@ class App(_Callback):
         if self._is_dry_run:
             # wait a little and rearming FDL acquisition
             _time.sleep(self._const.DEF_TIME2WAIT_INTLKREARM)
-            # sending interlock for all LLRFs systems, then wait
+            # sending interlock reset for all LLRFs systems, then wait
             for llrf in self._llrfs:
                 llrf.interlock_reset = 1
             _time.sleep(1)


### PR DESCRIPTION
Ana:
-  Add new redundancy EVRs for 08 and 14 sectors
- TODO: update LLRF PVs to use new IOC version, @murilobalves , could you please continue implementations in this PR? 

Murilo:
To be merged in companion with this PR https://github.com/lnls-sirius/dev-packages/pull/1110
- TODO: Discuss proper way to deal with two LLRF systems