### PR TITLE
Update DVF PVs after IOC upgrade

### DIFF
--- a/siriuspy/siriuspy/devices/dvf.py
+++ b/siriuspy/siriuspy/devices/dvf.py
@@ -101,8 +101,23 @@ class DVF(_Device):
     @property
     def intensity_saturation_value(self):
         """Image intensity saturation value."""
-        pixel_format_to_num_bits = {0: 8, 1: 12}  # 0: 'Mono8, 1: 'Mono12
-        data_type_to_num_bits = {0: 8, 1: 16} # 0: 'UInt8', 1: 'UInt16'
+        pixel_format_to_num_bits = {
+            0: 8,   # Mono8
+            1: 12,  # Mono12
+            2: 12   # Mono12Packed
+        }
+        data_type_to_num_bits = {
+            0: 8,   # Int8
+            1: 8,   # UInt8
+            2: 16,  # Int16
+            3: 16,  # Uint16
+            4: 32,  # Int32
+            5: 32,  # UInt32
+            6: 64,  # Int64
+            7: 64,  # UInt64
+            8: 32,  # Float32
+            9: 64,  # Float64
+        }
         used_bits = pixel_format_to_num_bits[self.pixel_format]
         max_bits = data_type_to_num_bits[self.data_type]
         max_intensity = (1 << used_bits) - 1

--- a/siriuspy/siriuspy/devices/dvf.py
+++ b/siriuspy/siriuspy/devices/dvf.py
@@ -62,7 +62,7 @@ class DVF(_Device):
         'cam1:PixelFormat', 'cam1:PixelFormat_RBV',
         'cam1:PixelSize', 'cam1:PixelSize_RBV',
         'cam1:Temperature',
-        'cam1:FAILURES_RBV', 'cam1:COMPLETED_RBV',
+        'cam1:ARFrameFailures', 'cam1:ARFramesCompleted',
         'image1:NDArrayPort', 'image1:NDArrayPort_RBV',
         'image1:EnableCallbacks', 'image1:EnableCallbacks_RBV',
         'image1:ArraySize0_RBV', 'image1:ArraySize1_RBV',
@@ -350,12 +350,12 @@ class DVF(_Device):
     @property
     def cam_frames_completed(self):
         """Return number of acquisition frames completed."""
-        return self['cam1:COMPLETED_RBV']
+        return self['cam1:ARFramesCompleted']
 
     @property
     def cam_frames_failures(self):
         """Return number of acquisition frames failures."""
-        return self['cam1:FAILURES_RBV']
+        return self['cam1:ARFrameFailures']
 
     def cmd_reset(self, timeout=None):
         """Reset DVF to a standard configuration."""
@@ -447,6 +447,8 @@ class DVF(_Device):
                 plug = plug.replace('cam', 'Cam')
                 plug = plug.replace('image', 'Image')
                 plug = plug.replace('Trans', 'Transf')
+                plug = plug.replace('ARFrameFailures', 'FAILURES_RBV')
+                plug = plug.replace('ARFramesCompleted', 'COMPLETED_RBV')
                 propty = plug + prop
             propty_name_map[propty] = propty
         return propty_name_map[propty]

--- a/siriuspy/siriuspy/devices/dvf.py
+++ b/siriuspy/siriuspy/devices/dvf.py
@@ -59,7 +59,6 @@ class DVF(_Device):
         'cam1:Gain', 'cam1:Gain_RBV',
         'cam1:GainAuto', 'cam1:GainAuto_RBV',
         'cam1:PixelFormat', 'cam1:PixelFormat_RBV',
-        'cam1:PixelSize', 'cam1:PixelSize_RBV',
         'cam1:GC_TemperatureAbs_RBV',
         'cam1:ARFrameFailures', 'cam1:ARFramesCompleted',
         'image1:NDArrayPort', 'image1:NDArrayPort_RBV',
@@ -325,16 +324,6 @@ class DVF(_Device):
     def data_type(self):
         """Return image data type."""
         return self['image1:DataType_RBV']
-
-    @property
-    def pixel_size(self):
-        """Return camera pixel size."""
-        return self['cam1:PixelSize_RBV']
-
-    @pixel_size.setter
-    def pixel_size(self, value):
-        """Set camera pixel size."""
-        self['cam1:PixelSize'] = value
 
     @property
     def cam_temperature(self):

--- a/siriuspy/siriuspy/devices/dvf.py
+++ b/siriuspy/siriuspy/devices/dvf.py
@@ -58,7 +58,6 @@ class DVF(_Device):
         'cam1:ImageMode', 'cam1:ImageMode_RBV',
         'cam1:Gain', 'cam1:Gain_RBV',
         'cam1:GainAuto', 'cam1:GainAuto_RBV',
-        'cam1:DataType', 'cam1:DataType_RBV',
         'cam1:PixelFormat', 'cam1:PixelFormat_RBV',
         'cam1:PixelSize', 'cam1:PixelSize_RBV',
         'cam1:GC_TemperatureAbs_RBV',
@@ -66,6 +65,7 @@ class DVF(_Device):
         'image1:NDArrayPort', 'image1:NDArrayPort_RBV',
         'image1:EnableCallbacks', 'image1:EnableCallbacks_RBV',
         'image1:ArraySize0_RBV', 'image1:ArraySize1_RBV',
+        'image1:DataType_RBV',
         'image1:ArrayData',
         'ROI1:NDArrayPort', 'ROI1:NDArrayPort_RBV',
         'ROI1:EnableCallbacks', 'ROI1:EnableCallbacks_RBV',
@@ -323,13 +323,8 @@ class DVF(_Device):
 
     @property
     def data_type(self):
-        """Return camera data type."""
-        return self['cam1:DataType_RBV']
-
-    @data_type.setter
-    def data_type(self, value):
-        """Set camera data type."""
-        self['cam1:DataType'] = value
+        """Return image data type."""
+        return self['image1:DataType_RBV']
 
     @property
     def pixel_size(self):
@@ -362,7 +357,6 @@ class DVF(_Device):
             'cam1:ArrayCallbacks': 1,  # Enable passing array
             'cam1:ImageMode': 2,  # Continuous
             'cam1:PixelFormat': 1,  # Mono12
-            'cam1:DataType': 1,  # UInt16 (maybe unnecessary)
             'ROI1:NDArrayPort': 'CAMPORT',  # Take img from camport
             'ROI1:EnableCallbacks': 1,  # Enable getting from NDArrayPort
             'ROI1:MinX': 0,  # [pixel]

--- a/siriuspy/siriuspy/devices/dvf.py
+++ b/siriuspy/siriuspy/devices/dvf.py
@@ -51,6 +51,7 @@ class DVF(_Device):
         'cam1:SizeY', 'cam1:SizeY_RBV',
         'cam1:MinX', 'cam1:MinX_RBV',
         'cam1:MinY', 'cam1:MinY_RBV',
+        'cam1:PortName_RBV',
         'cam1:ArrayCallbacks', 'cam1:ArrayCallbacks_RBV',
         'cam1:AcquireTime', 'cam1:AcquireTime_RBV',
         'cam1:AcquirePeriod', 'cam1:AcquirePeriod_RBV',
@@ -66,6 +67,7 @@ class DVF(_Device):
         'image1:ArraySize0_RBV', 'image1:ArraySize1_RBV',
         'image1:DataType_RBV',
         'image1:ArrayData',
+        'ROI1:PortName_RBV',
         'ROI1:NDArrayPort', 'ROI1:NDArrayPort_RBV',
         'ROI1:EnableCallbacks', 'ROI1:EnableCallbacks_RBV',
         'ROI1:MinX', 'ROI1:MinX_RBV',
@@ -346,7 +348,8 @@ class DVF(_Device):
             'cam1:ArrayCallbacks': 1,  # Enable passing array
             'cam1:ImageMode': 2,  # Continuous
             'cam1:PixelFormat': 1,  # Mono12
-            'ROI1:NDArrayPort': 'CAMPORT',  # Take img from camport
+            # ROI1 takes images from camera driver
+            'ROI1:NDArrayPort': self['cam1:PortName_RBV'],
             'ROI1:EnableCallbacks': 1,  # Enable getting from NDArrayPort
             'ROI1:MinX': 0,  # [pixel]
             'ROI1:MinY': 0,  # [pixel]
@@ -355,7 +358,8 @@ class DVF(_Device):
             'ROI1:EnableX': 1,  # Enable
             'ROI1:EnableY': 1,  # Enable
             'ROI1:ArrayCallbacks': 1,  # Enable passing array
-            'image1:NDArrayPort': 'ROI1',  # image1 takes img from ROI1
+            # image1 takes images from ROI1
+            'image1:NDArrayPort': self['ROI1:PortName_RBV'],
             'image1:EnableCallbacks': 1,  # Enable
             'Trans1:EnableCallbacks': 0,  # Disable
         }

--- a/siriuspy/siriuspy/devices/dvf.py
+++ b/siriuspy/siriuspy/devices/dvf.py
@@ -51,8 +51,6 @@ class DVF(_Device):
         'cam1:SizeY', 'cam1:SizeY_RBV',
         'cam1:MinX', 'cam1:MinX_RBV',
         'cam1:MinY', 'cam1:MinY_RBV',
-        'cam1:CenterX', 'cam1:CenterX_RBV',
-        'cam1:CenterY', 'cam1:CenterY_RBV',
         'cam1:ArrayCallbacks', 'cam1:ArrayCallbacks_RBV',
         'cam1:AcquireTime', 'cam1:AcquireTime_RBV',
         'cam1:AcquirePeriod', 'cam1:AcquirePeriod_RBV',

--- a/siriuspy/siriuspy/devices/dvf.py
+++ b/siriuspy/siriuspy/devices/dvf.py
@@ -76,7 +76,6 @@ class DVF(_Device):
         'ROI1:EnableX', 'ROI1:EnableX_RBV',
         'ROI1:EnableY', 'ROI1:EnableY_RBV',
         'ROI1:ArrayCallbacks', 'ROI1:ArrayCallbacks_RBV',
-        'ffmstream1:EnableCallbacks', 'ffmstream1:EnableCallbacks_RBV',
         'Trans1:EnableCallbacks', 'Trans1:EnableCallbacks_RBV',
         )
 
@@ -375,7 +374,6 @@ class DVF(_Device):
             'ROI1:ArrayCallbacks': 1,  # Enable passing array
             'image1:NDArrayPort': 'ROI1',  # image1 takes img from ROI1
             'image1:EnableCallbacks': 1,  # Enable
-            'ffmstream1:EnableCallbacks': 0,  # Disable
             'Trans1:EnableCallbacks': 0,  # Disable
         }
 

--- a/siriuspy/siriuspy/devices/dvf.py
+++ b/siriuspy/siriuspy/devices/dvf.py
@@ -61,7 +61,7 @@ class DVF(_Device):
         'cam1:DataType', 'cam1:DataType_RBV',
         'cam1:PixelFormat', 'cam1:PixelFormat_RBV',
         'cam1:PixelSize', 'cam1:PixelSize_RBV',
-        'cam1:Temperature',
+        'cam1:GC_TemperatureAbs_RBV',
         'cam1:ARFrameFailures', 'cam1:ARFramesCompleted',
         'image1:NDArrayPort', 'image1:NDArrayPort_RBV',
         'image1:EnableCallbacks', 'image1:EnableCallbacks_RBV',
@@ -345,7 +345,7 @@ class DVF(_Device):
     @property
     def cam_temperature(self):
         """Return camera temperature"""
-        return self['cam1:Temperature']
+        return self['cam1:GC_TemperatureAbs_RBV']
 
     @property
     def cam_frames_completed(self):
@@ -449,6 +449,7 @@ class DVF(_Device):
                 plug = plug.replace('Trans', 'Transf')
                 plug = plug.replace('ARFrameFailures', 'FAILURES_RBV')
                 plug = plug.replace('ARFramesCompleted', 'COMPLETED_RBV')
+                plug = plug.replace('GC_TemperatureAbs_RBV', 'Temp-Mon')
                 propty = plug + prop
             propty_name_map[propty] = propty
         return propty_name_map[propty]


### PR DESCRIPTION
During this shutdown, Carcará-X (CAX) beamline had its camera IOCs upgraded. This implied in some changes in PV names that were abstracted by the `DVF` device. Update them accordingly.

Whenever possible, they have been replaced by their [ADDriver standard names][1], since they are more stable. Unfortunately, that's not always the case. Since the accelerator cameras still operate with the previous driver, naming conversion is still implemented for BO_DVF.

Such conversions should be entirely removed from this abstraction layer when high-level PVs (see cnpem/ad-aravis-epics-ioc#3)  are tested and deployed for CAX as well, which will happen as a second step.

[1]: https://areadetector.github.io/areaDetector/ADCore/ADDriver.html