### PR TITLE
Fix FamBPMs

### DIFF
--- a/siriuspy/siriuspy/devices/bpm_fam.py
+++ b/siriuspy/siriuspy/devices/bpm_fam.py
@@ -246,7 +246,7 @@ class FamBPMs(_DeviceSet):
         """Convert signal to generate PV name."""
         if sig == 'S':
             sig = 'Sum'
-        elif sig == 'X' or 'Y' or 'Q':
+        elif sig in 'XYQ':
             sig = 'Pos' + sig
         else:
             sig = 'Ampl' + sig


### PR DESCRIPTION
 Fix logic in creation of amplitudes PV names.

This bug was not allowing us to equalize the BPMs gains.