### PR TITLE
DEV.FIX: fix PV name in BPM device.

### DIFF
--- a/siriuspy/siriuspy/devices/bpm.py
+++ b/siriuspy/siriuspy/devices/bpm.py
@@ -687,12 +687,12 @@ class BPM(_Device):
     @property
     def acq_trig_datapol(self):
         """."""
-        return self['GENTriggerDataPol-RB']
+        return self['GENTriggerDataPol-Sts']
 
     @acq_trig_datapol.setter
     def acq_trig_datapol(self, val):
         """."""
-        self['GENTriggerDataPol-SP'] = val
+        self['GENTriggerDataPol-Sel'] = val
 
     @property
     def acq_nrsamples_post(self):


### PR DESCRIPTION
The PV name was correct in the properties list, but wrong in the setter and getter. This also caused the BPM Device to report itself as disconnected, if it was initialized with connection to all BPM PVs.