### PR TITLE
Fix IDFF device use in IDFF IOC class

### DIFF
--- a/siriuspy/siriuspy/devices/idff.py
+++ b/siriuspy/siriuspy/devices/idff.py
@@ -254,9 +254,10 @@ class IDFF(_DeviceSet):
     class DEVICES(_ID.DEVICES):
         """."""
 
-    def __init__(self, devname):
+    def __init__(self, devname, with_devctrl=True):
         """."""
         devname = _SiriusPVName(devname)
+        self._with_devctrl = with_devctrl
 
         # check if device exists
         if devname not in IDFF.DEVICES.ALL:
@@ -273,7 +274,9 @@ class IDFF(_DeviceSet):
         (self._devctrl, self._devid, self._devsch, self._devscv,
          self._devsqs, self._devslc) = self._create_devices(devname)
 
-        devices = [self._devctrl, self._devid, ]
+        devices = list()
+        if self._with_devctrl:
+            devices += [self._devctrl, ]
         devices += self._devsch
         devices += self._devscv
         devices += self._devsqs
@@ -547,7 +550,7 @@ class IDFF(_DeviceSet):
             _time.sleep(time_interval / (nrpts - 1))
 
     def _create_devices(self, devname):
-        devctrl = IDFFCtrl(devname=devname)
+        devctrl = IDFFCtrl(devname=devname) if self._with_devctrl else None
         pol_mon = _ID.get_idclass(devname).PARAM_PVS.POL_MON
         params = (
             self._pparametername, self._kparametername, pol_mon)

--- a/siriuspy/siriuspy/devices/idff.py
+++ b/siriuspy/siriuspy/devices/idff.py
@@ -276,7 +276,9 @@ class IDFF(_DeviceSet):
 
         devices = list()
         if self._with_devctrl:
-            devices += [self._devctrl, ]
+            devices += [self._devctrl, self._devid]
+        else:
+            devices += [self._devid, ]
         devices += self._devsch
         devices += self._devscv
         devices += self._devsqs

--- a/siriuspy/siriuspy/idff/main.py
+++ b/siriuspy/siriuspy/idff/main.py
@@ -34,7 +34,7 @@ class App(_Callback):
         self.read_autosave_file()
 
         # IDFF object with IDFF config
-        self._idff = _IDFF(idname)
+        self._idff = _IDFF(idname, with_devctrl=False)
 
         # load idff in configdb
         self._load_config(self._config_name)


### PR DESCRIPTION
Lately the IDFF device was modified in order to add PVs of the IDFF controller itself, besides those of the ID and those related to correctors. This is convenient for jupyter notebooks that deal with various aspects of the FF system. But the high level FF IOC itself uses the IDFF device. An additional option was added in the IDFF device constructor that allows for choosing when to add the IDFF Ctrl device to the devices set.