### PR TITLE
Remove dependency on pyepics.

### DIFF
--- a/siriuspy/siriuspy/util.py
+++ b/siriuspy/siriuspy/util.py
@@ -9,7 +9,11 @@ import inspect as _inspect
 import subprocess as _sp
 import datetime as _datetime
 
-import epics as _epics
+try:
+    import epics as _epics
+except:
+    _epics = None
+
 
 from mathphys import beam_optics as _beam
 from siriuspy import envars as _envars


### PR DESCRIPTION
This makes the code that uses siriuspy less restricted to some dependencies, such as pyepics, if it is only using ps_search.