### PR TITLE
Update subpackages to handle new correctors

### DIFF
--- a/siriuspy/siriuspy/cycle/util.py
+++ b/siriuspy/siriuspy/cycle/util.py
@@ -50,7 +50,7 @@ def get_psnames(isadv=False):
     to_remove = _PSSearch.get_psnames({'sec': 'TS', 'idx': '(0|1E2)'})
     # explicitly remove some ID correctors
     to_remove.extend(_PSSearch.get_psnames(
-        {'sec': 'SI', 'sub': '(10SB|17SA)', 'dev': '(CH|CV|QS)'}))
+        {'sec': 'SI', 'sub': '(08SB|10SB|14SB|17SA)', 'dev': '(CH|CV|QS)'}))
     # explicitly remove septa feedforward fast correctors (disconnected)
     to_remove.extend(_PSSearch.get_psnames(
         {'sec': 'SI', 'sub': '(01M1|01M2)', 'dev': '(FCH|FCV)'}))

--- a/siriuspy/siriuspy/cycle/util.py
+++ b/siriuspy/siriuspy/cycle/util.py
@@ -23,26 +23,35 @@ def get_psnames(isadv=False):
     names = _PSSearch.get_psnames({'sec': '(LI|TB|TS)', 'dis': 'PS'})
 
     if not isadv:
+        # family magnets
         names.extend(_PSSearch.get_psnames(
             {'sec': 'SI', 'sub': 'Fam', 'dis': 'PS', 'dev': '(B|Q.*|S.*)'}))
+        # vertical correctors in individual magnets
         names.extend(_PSSearch.get_psnames(
             {'sec': 'SI', 'sub': '[0-2][0-9]C2', 'dis': 'PS',
              'dev': 'CV', 'idx': '2'}))
+        # skew quadrupoles in individual magnets
         names.extend(_PSSearch.get_psnames(
             {'sec': 'SI', 'sub': '[0-2][0-9]C2', 'dis': 'PS',
              'dev': 'QS'}))
+        # ID correctors
         names.extend(_PSSearch.get_psnames(
             {'sec': 'SI', 'sub': '[0-2][0-9]S(A|B|P)', 'dis': 'PS',
-             'dev': '(CH|CV|QS)'}))
+             'dev': '(CH|CV|QS)'}))  # do not include VPU correctors (CC)
+        # fast correctors
         names.extend(_PSSearch.get_psnames(
             {'sec': 'SI', 'dis': 'PS', 'dev': 'FC.*'}))
     else:
+        # all magnets
         names.extend(_PSSearch.get_psnames(
             {'sec': 'SI', 'dis': 'PS', 'dev': '(B|Q.*|S.*|C.*|FC.*)'}))
 
+    # explicitly remove TS auxiliary correctors (coils in quadrupoles)
     to_remove = _PSSearch.get_psnames({'sec': 'TS', 'idx': '(0|1E2)'})
+    # explicitly remove some ID correctors
     to_remove.extend(_PSSearch.get_psnames(
         {'sec': 'SI', 'sub': '(10SB|17SA)', 'dev': '(CH|CV|QS)'}))
+    # explicitly remove septa feedforward fast correctors (disconnected)
     to_remove.extend(_PSSearch.get_psnames(
         {'sec': 'SI', 'sub': '(01M1|01M2)', 'dev': '(FCH|FCV)'}))
     for name in to_remove:


### PR DESCRIPTION
- Include comments to explicitly document that new VPU correctors will not be included in cycle procedure
- Improve code documentation

New correctors were added as known type corrector-horizontal at companion PR at control-system-constants (lnls-sirius/control-system-constants#337), if we need to create a new type, let us implement this modifications in this PR.