### PR TITLE
Update orbit interlock HLIOC 

### DIFF
--- a/siriuspy/siriuspy/devices/rf.py
+++ b/siriuspy/siriuspy/devices/rf.py
@@ -567,9 +567,10 @@ class ASLLRF(_Device):
     """AS LLRF."""
 
     PROPERTIES_INTERLOCK = (
-        'FIMOrbitIntlk-Sel', 'FIMOrbitIntlk-Sts', 'IntlkAll-Mon',
+        'FIMLLRF1-Sel', 'FIMLLRF1-Sts', 'IntlkAll-Mon',
         'FIMManual-Sel', 'FIMManual-Sts',
         'IntlkManual-Sel', 'IntlkManual-Sts', 'IntlkReset-Cmd',
+        'Inp1Intlk-Mon', 'Inp2Intlk-Mon',
     )
 
     VoltIncRates = _get_namedtuple('VoltIncRates', (
@@ -895,12 +896,12 @@ class _BaseLLRF(_Device):
     @property
     def fast_interlock_monitor_orbit(self):
         """."""
-        return self['FIMOrbitIntlk-Sts']
+        return self['FIMLLRF1-Sts']
 
     @fast_interlock_monitor_orbit.setter
     def fast_interlock_monitor_orbit(self, value):
         """."""
-        self['FIMOrbitIntlk-Sel'] = value
+        self['FIMLLRF1-Sel'] = value
 
     @property
     def fast_interlock_monitor_manual(self):
@@ -926,6 +927,16 @@ class _BaseLLRF(_Device):
     def interlock_mon(self):
         """."""
         return self['IntlkAll-Mon']
+
+    @property
+    def interlock_input1_mon(self):
+        """."""
+        return self['Inp1Intlk-Mon']
+
+    @property
+    def interlock_input2_mon(self):
+        """."""
+        return self['Inp2Intlk-Mon']
 
     def cmd_reset_interlock(self, wait=1):
         """Reset interlocks."""

--- a/siriuspy/siriuspy/orbintlk/csdev.py
+++ b/siriuspy/siriuspy/orbintlk/csdev.py
@@ -140,6 +140,7 @@ class Const(_csdev.Const):
         ('TRIGGER_PM14RcvInSel-SP', 2),
     )
     REDUNDANCY_TABLE = {
+        'IA-06RaBPM:TI-AMCFPGAEVR': 'IA-06RaBPM:TI-EVR',
         'IA-08RaBPM:TI-AMCFPGAEVR': 'IA-08RaBPM:TI-EVR',
         'IA-10RaBPM:TI-AMCFPGAEVR': 'IA-10RaBPM:TI-EVR',
         'IA-14RaBPM:TI-AMCFPGAEVR': 'IA-14RaDiag03:TI-EVE',


### PR DESCRIPTION
- Update LLRF configurations to consider new Input 1 (bit 5) as orbit interlock input
- Add new IA-06RaBPM:TI-EVR to the list of timing redundancy devices