### PR TITLE
Update function create_static_table

### DIFF
--- a/siriuspy/siriuspy/search/ll_time_search.py
+++ b/siriuspy/siriuspy/search/ll_time_search.py
@@ -16,6 +16,7 @@ class LLTimeSearch:
     """Get the timing devices connections."""
 
     LLRegExp = _re.compile('([A-Z]+)([0-9]{0,2})', _re.IGNORECASE)
+    TrigSrcDevs = {'EVR', 'EVE', 'AMCFPGAEVR'}
 
     # defines the relations between input and output of the timing devices.
     In2OutMap = {
@@ -23,8 +24,8 @@ class LLTimeSearch:
             'UPLINK': (
                 'OUT0', 'OUT1', 'OUT2', 'OUT3',
                 'OUT4', 'OUT5', 'OUT6', 'OUT7',
-                ),
-            },
+            ),
+        },
         'EVR': {
             'UPLINK': (
                 'OTP0', 'OTP1', 'OTP2', 'OTP3', 'OTP4', 'OTP5',
@@ -34,8 +35,8 @@ class LLTimeSearch:
                 'OUT0', 'OUT1', 'OUT2', 'OUT3',
                 'OUT4', 'OUT5', 'OUT6', 'OUT7',
                 'DIN0', 'DIN1', 'DIN2',
-                ),
-            },
+            ),
+        },
         'EVE': {
             'UPLINK': (
                 'OTP0', 'OTP1', 'OTP2', 'OTP3', 'OTP4', 'OTP5',
@@ -45,43 +46,43 @@ class LLTimeSearch:
                 'OUT0', 'OUT1', 'OUT2', 'OUT3',
                 'OUT4', 'OUT5', 'OUT6', 'OUT7',
                 'RFOUT', 'DIN0', 'DIN1', 'DIN2',
-                ),
-            },
+            ),
+        },
         'AMCFPGAEVR': {
             'SFP8': (
                 'FMC1CH1', 'FMC1CH2', 'FMC1CH3', 'FMC1CH4', 'FMC1CH5',
                 'FMC2CH1', 'FMC2CH2', 'FMC2CH3', 'FMC2CH4', 'FMC2CH5',
                 'CRT0', 'CRT1', 'CRT2', 'CRT3', 'CRT4',
                 'CRT5', 'CRT6', 'CRT7',
-                ),
-            },
+            ),
+        },
         'OEMultSFP': {
             'OE1': ('OUT1', ),
             'OE2': ('OUT2', ),
             'OE3': ('OUT3', ),
             'OE4': ('OUT4', ),
-            },
+        },
         'OEMultPOF': {
             'IN1': ('OUT1', ),
             'IN2': ('OUT2', ),
             'IN3': ('OUT3', ),
             'IN4': ('OUT4', ),
-            },
+        },
         'OESglPOF': {
             'IN': ('OUT', ),
-            },
+        },
         'OESglSFP': {
             'INRX': ('OUT', 'INTX'),
-            },
+        },
         'Fout': {
             'UPLINK': (
                 'OUT0', 'OUT1', 'OUT2', 'OUT3',
                 'OUT4', 'OUT5', 'OUT6', 'OUT7',
-                ),
-            },
+            ),
+        },
         'UDC': {
             'SYNCIN': ('BCKPLN', 'SYNCOUT'),
-            },
+        },
         'Crate': {
             'CRT0': ('CRT0', ),
             'CRT1': ('CRT1', ),
@@ -91,10 +92,10 @@ class LLTimeSearch:
             'CRT5': ('CRT5', ),
             'CRT6': ('CRT6', ),
             'CRT7': ('CRT7', ),
-            },
+        },
         'OERFRx': {'OPTICALACP': ('SIGNAL', )},
         'OERFTx': {'SIGNAL': ('OPTICALACP', )},
-        }
+    }
     In2OutMap['DIO'] = {
         'P{0:03d}'.format(i): ('P{0:03d}'.format(i), ) for i in range(110)}
     In2OutMap['DIO'].update({
@@ -526,10 +527,9 @@ class LLTimeSearch:
             cls._devs_twds_evg.keys() - cls._devs_from_evg.keys())
         cls._all_devices = (
             cls._devs_from_evg.keys() | cls._devs_twds_evg.keys())
-        cls._trig_src_devs = set(
-                _get_device_names({'dev': 'EVR'}) +
-                _get_device_names({'dev': 'EVE'}) +
-                _get_device_names({'dev': 'AMCFPGAEVR'}))
+        cls._trig_src_devs = set()
+        for dev in cls.TrigSrcDevs:
+            cls._trig_src_devs.update(_get_device_names({'dev': dev}))
         cls._fout_devs = set(_get_device_names({'dev': 'Fout'}))
         cls._evg_devs = set(_get_device_names({'dev': 'EVG'}))
 

--- a/siriuspy/siriuspy/timesys/static_table.py
+++ b/siriuspy/siriuspy/timesys/static_table.py
@@ -45,8 +45,10 @@ def create_static_table(fname=None, local=False, logfile=None):
     else:
         data = read_data_from_google()
     _log.info(_disclaimer)
-    chans = _get_channels_from_data(data)
-    chans_used, chans_nused = _sort_connection_table(chans)
+    chans_used = _get_channels_from_data(data)
+    chans_used, chans_nused2 = _filter_connection_table(chans_used)
+    chans_used, chans_nused = _sort_connection_table(chans_used)
+    chans_nused = sorted(set(chans_nused + chans_nused2))
     _print_tables(chans_used, chans_nused)
 
 
@@ -80,7 +82,6 @@ def read_data_from_google():
         spreadsheetId='19lNNPWxZJv5s-VTrwZRMNWLDMqdHzOQa3ZDIw5neYFI',
         range='Cabos e Fibras').execute()
     values = result.get('values', [])
-
     if not values:
         raise ValueError('Error loading file from google')
     return values
@@ -132,6 +133,36 @@ def _get_channels_from_data(data):
 def _check_device_and_port(dev, por):
     por = por.upper().translate(str.maketrans('', '', ' _-'))
     return _NAMES2CONVERT.get(dev, dev) + ':' + por
+
+
+def _filter_connection_table(chans):
+    entries = []
+    trsrc = LLTimeSearch.TrigSrcDevs
+    in2ou = LLTimeSearch.In2OutMap
+    ou2in = LLTimeSearch.Out2InMap
+    for k1, k2 in chans:
+        if k1.dev in trsrc and k1.propty in (in2ou[k1.dev] | ou2in[k1.dev]):
+            entries.append(k1)
+        if k2.dev in trsrc and k2.propty in (in2ou[k2.dev] | ou2in[k2.dev]):
+            entries.append(k2)
+
+    chans_used = []
+    for entry in entries:
+        mark = list(range(len(chans)))
+        for i, ks in enumerate(chans):
+            k1, k2 = ks
+            if k1 == entry:
+                entries.extend(LLTimeSearch.get_channel_input(k2))
+                chans_used.append((k1, k2))
+                mark.remove(i)
+            if k2 == entry:
+                entries.extend(LLTimeSearch.get_channel_input(k1))
+                chans_used.append((k1, k2))
+                mark.remove(i)
+        chans = [chans[i] for i in mark]
+    chans_used = sorted(set(chans_used))
+    chans_nused = sorted(chans)
+    return chans_used, chans_nused
 
 
 def _sort_connection_table(chans):

--- a/siriuspy/tests/search/test_ll_time_search.py
+++ b/siriuspy/tests/search/test_ll_time_search.py
@@ -30,6 +30,7 @@ class TestLLTimeSearch(TestCase):
 
     public_interface = (
         'LLRegExp',
+        'TrigSrcDevs',
         'In2OutMap',
         'Out2InMap',
         'get_channel_input',


### PR DESCRIPTION
This version of the function removes all unused timing connections from the used connections list and add them to the unused connections list.

The previous version failed to do this for timing connections ending before any trigger source component (EVE, EVR and AMCFPGAEVR) was reached from EVG.