### PR TITLE
pwrsupply.ENH: suppress error logging for WfmOffset variable setpoint

### DIFF
--- a/siriuspy/siriuspy/pwrsupply/bsmp/commands.py
+++ b/siriuspy/siriuspy/pwrsupply/bsmp/commands.py
@@ -108,9 +108,17 @@ class PSBSMP(_BSMP):
             # not updated!
             read_flag = False
 
+        # NOTE: UDC firmware is erroneously responding with an timeout
+        # error when calling cfg_wfmref. So to avoid unnecessary logging
+        # we are going to suppress any error log from this command.
+        # This became a problem since SOFB sync mode uses waveform mode.
+        if func_id == PSBSMP.CONST.F_CFG_WFMREF:
+            print_error = False
+
         response = super().execute_function(
             func_id=func_id, input_val=input_val,
-            timeout=timeout, read_flag=read_flag)
+            timeout=timeout, read_flag=read_flag,
+            print_error=print_error)
 
         # introduces necessary sleeps
         # TODO: check with ELP if these numbers can be optimized further!

--- a/siriuspy/siriuspy/pwrsupply/pructrl/prucontroller.py
+++ b/siriuspy/siriuspy/pwrsupply/pructrl/prucontroller.py
@@ -13,7 +13,7 @@ from time import sleep as _sleep, time as _time
 from ...bsmp import SerialError as _SerialError
 from ...util import get_timestamp as _get_timestamp
 from ..bsmp.constants import __version__ as _firmware_version_siriuspy, \
-    _const_bsmp
+    _const_bsmp, ConstPSBSMP as _const_psbsmp
 from .psdevstate import PSDevState as _PSDevState
 from .udc import UDC as _UDC
 
@@ -709,8 +709,10 @@ class PRUController:
                 resp = self._udc[dev_id].execute_function(function_id, args)
                 ack[dev_id], data[dev_id] = resp
                 # check anomalous response
-                if ack[dev_id] != _const_bsmp.ACK_OK:
-                    print('PRUController: anomalous response !')
+                # to avoid unnecessary logging we skip error interception for
+                # F_CFG_WFMREF since UDC firmware is returning error code erroneously
+                is_cfg_wfmref = function_id == _const_psbsmp.F_CFG_WFMREF
+                if ack[dev_id] != _const_bsmp.ACK_OK and not is_cfg_wfmref:
                     datum = data[dev_id]
                     if isinstance(datum, str):
                         datum = ord(datum)


### PR DESCRIPTION
UDC firmware is erroneously responding with an timeout error when calling cfg_wfmref. So to avoid unnecessary logging we are going to suppress any error log from this command. This became a problem since SOFB sync mode uses waveform mode.