### PR TITLE
Fixed FIM quench pvs

### DIFF
--- a/siriuspy/siriuspy/clientconfigdb/types/as_rf.py
+++ b/siriuspy/siriuspy/clientconfigdb/types/as_rf.py
@@ -311,8 +311,8 @@ _pvs_sia_llrf = [
     ['RA-RaSIA01:RF-LLRF:FIMRFIn14-Sel', 0, 0.0],
     ['RA-RaSIA01:RF-LLRF:FIMRFIn15-Sel', 0, 0.0],
     ['RA-RaSIA01:RF-LLRF:FIMOrbitIntlk-Sel', 0, 0.0],
-    ['RA-RaSIA01:RF-LLRF:FIMQuenchCond1-Sts', 0, 0.0],
-    ['RA-RaSIA01:RF-LLRF:FIMEQuench-Sts', 0, 0.0],
+    ['RA-RaSIA01:RF-LLRF:FIMQuenchCond1-Sel', 0, 0.0],
+    ['RA-RaSIA01:RF-LLRF:FIMEQuench-Sel', 0, 0.0],
     # End switches logic
     ['RA-RaSIA01:RF-LLRF:EndSwLogicInv-Sel', 0, 0.0],
     # Beam trip logic
@@ -642,8 +642,8 @@ _pvs_sib_llrf = [
     ['RA-RaSIB01:RF-LLRF:FIMRFIn14-Sel', 0, 0.0],
     ['RA-RaSIB01:RF-LLRF:FIMRFIn15-Sel', 0, 0.0],
     ['RA-RaSIB01:RF-LLRF:FIMOrbitIntlk-Sel', 0, 0.0],
-    ['RA-RaSIB01:RF-LLRF:FIMQuenchCond1-Sts', 0, 0.0],
-    ['RA-RaSIB01:RF-LLRF:FIMEQuench-Sts', 0, 0.0],
+    ['RA-RaSIB01:RF-LLRF:FIMQuenchCond1-Sel', 0, 0.0],
+    ['RA-RaSIB01:RF-LLRF:FIMEQuench-Sel', 0, 0.0],
     # End switches logic
     ['RA-RaSIB01:RF-LLRF:EndSwLogicInv-Sel', 0, 0.0],
     # Beam trip logic


### PR DESCRIPTION
The SIA and SIB FIM quench pvs were with -Sts sufix instead of -Sel.