### PR TITLE
FOFB.FIX: update atol for PRBS levels.

### DIFF
--- a/siriuspy/siriuspy/devices/fofb_acq.py
+++ b/siriuspy/siriuspy/devices/fofb_acq.py
@@ -542,7 +542,7 @@ class FamFOFBSysId(_FamFOFBAcqBase):
 
     FOFBCTRL_CLASS = FOFBCtrlSysId
     FOFBPS_CLASS = FOFBPSSysId
-    DEF_ATOL_FOFBACC = 1e-6
+    DEF_ATOL_FOFBACC = 1e-4
 
     def __init__(self, **kws):
         """."""


### PR DESCRIPTION
As observed experimentally (SP=-0.15481 and RB=-0.15475), a lower precision must be used for these values. Otherwise, the application of the values is considered to have failed, and the control flow [1] doesn't progress to actually enabling the PRBS functionality.

[1] https://github.com/lnls-fac/apsuite/blob/b2152979aa6b08eb688f80a45690a3119dd5c6b7/apsuite/commisslib/meas_fofb_sysid.py#L373