### PR TITLE
Improve update of MTurn and SP orbits in SOFB

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # --- default owners of the repo
-* @anacso17 @fernandohds564 @murilobalves @xresende 
+* @anacso17 @fernandohds564 @xresende 

--- a/siriuspy/siriuspy/sofb/base_class.py
+++ b/siriuspy/siriuspy/sofb/base_class.py
@@ -1,6 +1,7 @@
 """Definition module."""
 import logging as _log
 import math as _math
+import time as _time
 
 import numpy as _np
 
@@ -110,18 +111,17 @@ class BaseTimingConfig(_Callback):
         self._config_ok_vals = {}
         self._config_pvs_rb = {}
         self._config_pvs_sp = {}
+        self._pvs = {}
         self.put_enable = True
 
     @property
     def connected(self):
         """Status connected."""
         conn = True
-        for pv in self._config_pvs_rb.values():
-            if not pv.connected:
-                _log.debug("NOT CONN: " + pv.pvname)
-            conn &= pv.connected
-
-        for pv in self._config_pvs_sp.values():
+        pvs = list(self._config_pvs_rb.values())
+        pvs += list(self._config_pvs_rb.values())
+        pvs += list(self._pvs.values())
+        for pv in pvs:
             if not pv.connected:
                 _log.debug("NOT CONN: " + pv.pvname)
             conn &= pv.connected
@@ -160,6 +160,18 @@ class BaseTimingConfig(_Callback):
         for k, pvo in self._config_pvs_sp.items():
             if k in self._config_ok_vals:
                 pvo.put(self._config_ok_vals[k], wait=False)
+        return True
+
+    def wait_for_connection(self, timeout=10):
+        """."""
+        t0_ = _time.time()
+        pvs = list(self._config_pvs_rb.values())
+        pvs += list(self._config_pvs_rb.values())
+        pvs += list(self._pvs.values())
+        for pv in pvs:
+            tout = timeout - (_time.time() - t0_)
+            if tout <= 0 or not pv.wait_for_connection(tout):
+                return False
         return True
 
 

--- a/siriuspy/siriuspy/sofb/bpms.py
+++ b/siriuspy/siriuspy/sofb/bpms.py
@@ -16,12 +16,10 @@ TIMEOUT = 0.05
 class BPM(_BaseTimingConfig):
     """."""
 
-    MAX_UPT_CNT = 20  # equivalent of 10s of orbit update after Acq. PV update
-
     def __init__(self, name, callback=None):
         """."""
         super().__init__(name[:2], callback)
-        self.needs_update_cnt = self.MAX_UPT_CNT
+        self.has_news = True
 
         self._name = name
         self._orb_conv_unit = self._csorb.ORBIT_CONVERSION_UNIT
@@ -105,6 +103,7 @@ class BPM(_BaseTimingConfig):
             "ACQSamplesPre": "GENSamplesPre-RB",
             "ACQSamplesPost": "GENSamplesPost-RB",
             "ACQTriggerEvent": "GENTriggerEvent-Cmd",
+            "ACQCount": "GENCount-Mon",
             "ACQStatus": "GENStatus-Mon",
             "ACQTrigger": "GENTrigger-Sts",
             "ACQTriggerRep": "GENTriggerRep-Sts",
@@ -124,9 +123,9 @@ class BPM(_BaseTimingConfig):
         self._config_pvs_rb = {
             k: _PV(pvpref + v, **opt) for k, v in pvs.items()
         }
-        self._config_pvs_rb["ACQStatus"].auto_monitor = True
-        self._config_pvs_rb["ACQStatus"].add_callback(
-            self._reset_needs_update_cnt
+        self._config_pvs_rb["ACQCount"].auto_monitor = True
+        self._config_pvs_rb["ACQCount"].add_callback(
+            self._reset_has_news
         )
 
     @property
@@ -745,9 +744,9 @@ class BPM(_BaseTimingConfig):
             + th9 * pol[14]
         )
 
-    def _reset_needs_update_cnt(self, *args, **kwargs):
+    def _reset_has_news(self, *args, **kwargs):
         _ = args, kwargs
-        self.needs_update_cnt = self.MAX_UPT_CNT
+        self.has_news = True
 
 
 class TimingConfig(_BaseTimingConfig):

--- a/siriuspy/siriuspy/sofb/bpms.py
+++ b/siriuspy/siriuspy/sofb/bpms.py
@@ -25,21 +25,21 @@ class BPM(_BaseTimingConfig):
         self._orb_conv_unit = self._csorb.ORBIT_CONVERSION_UNIT
         pvpref = LL_PREF + ("-" if LL_PREF else "") + self._name + ":"
         opt = {"connection_timeout": TIMEOUT, "auto_monitor": False}
-        self._poskx = _PV(pvpref + "PosKx-RB", **opt)
-        self._posky = _PV(pvpref + "PosKy-RB", **opt)
-        self._ksum = _PV(pvpref + "PosKsum-RB", **opt)
-        self._polyx = _PV(pvpref + "GEN_PolyXArrayCoeff-RB", **opt)
-        self._polyy = _PV(pvpref + "GEN_PolyYArrayCoeff-RB", **opt)
-        self._arraya = _PV(pvpref + "GENAmplAData", **opt)
-        self._arrayb = _PV(pvpref + "GENAmplBData", **opt)
-        self._arrayc = _PV(pvpref + "GENAmplCData", **opt)
-        self._arrayd = _PV(pvpref + "GENAmplDData", **opt)
-        self._arrayx = _PV(pvpref + "GENPosXData", **opt)
-        self._arrayy = _PV(pvpref + "GENPosYData", **opt)
-        self._arrays = _PV(pvpref + "GENSumData", **opt)
+        self._pvs['poskx'] = _PV(pvpref + "PosKx-RB", **opt)
+        self._pvs['posky'] = _PV(pvpref + "PosKy-RB", **opt)
+        self._pvs['ksum'] = _PV(pvpref + "PosKsum-RB", **opt)
+        self._pvs['polyx'] = _PV(pvpref + "GEN_PolyXArrayCoeff-RB", **opt)
+        self._pvs['polyy'] = _PV(pvpref + "GEN_PolyYArrayCoeff-RB", **opt)
+        self._pvs['arraya'] = _PV(pvpref + "GENAmplAData", **opt)
+        self._pvs['arrayb'] = _PV(pvpref + "GENAmplBData", **opt)
+        self._pvs['arrayc'] = _PV(pvpref + "GENAmplCData", **opt)
+        self._pvs['arrayd'] = _PV(pvpref + "GENAmplDData", **opt)
+        self._pvs['arrayx'] = _PV(pvpref + "GENPosXData", **opt)
+        self._pvs['arrayy'] = _PV(pvpref + "GENPosYData", **opt)
+        self._pvs['arrays'] = _PV(pvpref + "GENSumData", **opt)
         opt.pop("auto_monitor")
-        self._offsetx = _PV(pvpref + "PosXOffset-RB", **opt)
-        self._offsety = _PV(pvpref + "PosYOffset-RB", **opt)
+        self._pvs['offsetx'] = _PV(pvpref + "PosXOffset-RB", **opt)
+        self._pvs['offsety'] = _PV(pvpref + "PosYOffset-RB", **opt)
         self._config_ok_vals = {
             "SwMode": _CSBPM.SwModes.switching,
             "ACQChannel": _CSBPM.AcqChan.ADC,
@@ -132,32 +132,6 @@ class BPM(_BaseTimingConfig):
     def name(self):
         """."""
         return self._name
-
-    @property
-    def connected(self):
-        """."""
-        conn = super().connected
-        pvs = (
-            self._arrayx,
-            self._arrayy,
-            self._arrays,
-            self._offsetx,
-            self._offsety,
-            self._polyx,
-            self._polyy,
-            self._arraya,
-            self._arrayb,
-            self._arrayc,
-            self._arrayd,
-            self._poskx,
-            self._posky,
-            self._ksum,
-        )
-        for pvobj in pvs:
-            if not pvobj.connected:
-                _log.debug("NOT CONN: " + pvobj.pvname)
-            conn &= pvobj.connected
-        return conn
 
     @property
     def is_ok(self):
@@ -272,7 +246,7 @@ class BPM(_BaseTimingConfig):
     def poskx(self):
         """."""
         defv = 1
-        pvobj = self._poskx
+        pvobj = self._pvs['poskx']
         val = pvobj.value if pvobj.connected else defv
         return val if val else defv
 
@@ -280,14 +254,14 @@ class BPM(_BaseTimingConfig):
     def posky(self):
         """."""
         defv = 1
-        pvobj = self._posky
+        pvobj = self._pvs['posky']
         val = pvobj.value if pvobj.connected else defv
         return val if val else defv
 
     @property
     def polyx(self):
         """."""
-        pvobj = self._polyx
+        pvobj = self._pvs['polyx']
         if pvobj.connected:
             val = pvobj.value
             if val is not None:
@@ -299,7 +273,7 @@ class BPM(_BaseTimingConfig):
     @property
     def polyy(self):
         """."""
-        pvobj = self._polyy
+        pvobj = self._pvs['polyy']
         if pvobj.connected:
             val = pvobj.value
             if val is not None:
@@ -312,38 +286,38 @@ class BPM(_BaseTimingConfig):
     def ksum(self):
         """."""
         defv = 1
-        pvobj = self._ksum
+        pvobj = self._pvs['ksum']
         val = pvobj.value if pvobj.connected else defv
         return val if val else defv
 
     @property
     def arraya(self):
         """."""
-        pvobj = self._arraya
+        pvobj = self._pvs['arraya']
         return pvobj.get() if pvobj.connected else None
 
     @property
     def arrayb(self):
         """."""
-        pvobj = self._arrayb
+        pvobj = self._pvs['arrayb']
         return pvobj.get() if pvobj.connected else None
 
     @property
     def arrayc(self):
         """."""
-        pvobj = self._arrayc
+        pvobj = self._pvs['arrayc']
         return pvobj.get() if pvobj.connected else None
 
     @property
     def arrayd(self):
         """."""
-        pvobj = self._arrayd
+        pvobj = self._pvs['arrayd']
         return pvobj.get() if pvobj.connected else None
 
     @property
     def mtposx(self):
         """."""
-        pvobj = self._arrayx
+        pvobj = self._pvs['arrayx']
         val = pvobj.get() if pvobj.connected else None
         if val is not None:
             return self._orb_conv_unit * val
@@ -351,7 +325,7 @@ class BPM(_BaseTimingConfig):
     @property
     def mtposy(self):
         """."""
-        pvobj = self._arrayy
+        pvobj = self._pvs['arrayy']
         val = pvobj.get() if pvobj.connected else None
         if val is not None:
             return self._orb_conv_unit * val
@@ -359,7 +333,7 @@ class BPM(_BaseTimingConfig):
     @property
     def mtsum(self):
         """."""
-        pvobj = self._arrays
+        pvobj = self._pvs['arrays']
         val = pvobj.get() if pvobj.connected else None
         if val is not None:
             return val
@@ -367,7 +341,7 @@ class BPM(_BaseTimingConfig):
     @property
     def offsetx(self):
         """."""
-        pvobj = self._offsetx
+        pvobj = self._pvs['offsetx']
         val = pvobj.value if pvobj.connected else None
         if val is not None:
             return self._orb_conv_unit * val
@@ -375,7 +349,7 @@ class BPM(_BaseTimingConfig):
     @property
     def offsety(self):
         """."""
-        pvobj = self._offsety
+        pvobj = self._pvs['offsety']
         val = pvobj.value if pvobj.connected else None
         if val is not None:
             return self._orb_conv_unit * val

--- a/siriuspy/siriuspy/sofb/correctors.py
+++ b/siriuspy/siriuspy/sofb/correctors.py
@@ -29,24 +29,13 @@ class Corrector(_BaseTimingConfig):
         """Init method."""
         super().__init__(corr_name[:2])
         self._name = _PVName(corr_name)
-        self._sp = None
-        self._rb = None
+        self._pvs['sp'] = None
+        self._pvs['rb'] = None
 
     @property
     def name(self):
         """Corrector name."""
         return self._name
-
-    @property
-    def connected(self):
-        """Status connected."""
-        conn = super().connected
-        pvs = (self._sp, self._rb)
-        for pv in pvs:
-            if not pv.connected:
-                _log.debug("NOT CONN: " + pv.pvname)
-            conn &= pv.connected
-        return conn
 
     @property
     def opmode_ok(self):
@@ -80,13 +69,13 @@ class Corrector(_BaseTimingConfig):
     @property
     def value(self):
         """Value."""
-        if self._rb.connected:
-            return self._rb.value
+        if self._pvs['rb'].connected:
+            return self._pvs['rb'].value
 
     @value.setter
     def value(self, val):
         """."""
-        self._sp.put(val, wait=False)
+        self._pvs['sp'].put(val, wait=False)
 
     @property
     def refvalue(self):
@@ -107,8 +96,8 @@ class RFCtrl(Corrector):
         self._name = self._csorb.RF_GEN_NAME
         opt = {"connection_timeout": TIMEOUT}
         pvpref = LL_PREF + ("-" if LL_PREF else "") + self._name
-        self._sp = _PV(pvpref + ":GeneralFreq-SP", **opt)
-        self._rb = _PV(pvpref + ":GeneralFreq-RB", **opt)
+        self._pvs['sp'] = _PV(pvpref + ":GeneralFreq-SP", **opt)
+        self._pvs['rb'] = _PV(pvpref + ":GeneralFreq-RB", **opt)
         self._config_ok_vals = {"PwrState": 1}
         self._config_pvs_sp = dict()
         self._config_pvs_rb = dict()
@@ -116,8 +105,8 @@ class RFCtrl(Corrector):
     @property
     def value(self):
         """Value."""
-        if self._rb.connected:
-            return self._rb.value
+        if self._pvs['rb'].connected:
+            return self._pvs['rb'].value
 
     @value.setter
     def value(self, freq):
@@ -131,7 +120,7 @@ class RFCtrl(Corrector):
         npoints = int(delta // self.MAX_DELTA) + 2
         freq_span = _np.linspace(freq0, freq, npoints)[1:]
         for i, freq in enumerate(freq_span, 1):
-            self._sp.put(freq, wait=False)
+            self._pvs['sp'].put(freq, wait=False)
             if i != freq_span.size:
                 _time.sleep(1)
 
@@ -158,16 +147,16 @@ class CHCV(Corrector):
         )
         pvrb = pvsp.substitute(propty_suffix="RB")
         pvref = pvsp.substitute(propty_name="KickRef", propty_suffix="Mon")
-        self._sp = _PV(pvsp, **opt)
-        self._rb = _PV(pvrb, **opt)
-        self._ref = _PV(pvref, **opt)
+        self._pvs['sp'] = _PV(pvsp, **opt)
+        self._pvs['rb'] = _PV(pvrb, **opt)
+        self._pvs['ref'] = _PV(pvref, **opt)
 
         pvoffwfmsp = self._name.substitute(
             prefix=LL_PREF, propty_name='WfmOffsetKick', propty_suffix='SP')
         pvoffwfmrb = self._name.substitute(
             prefix=LL_PREF, propty_name='WfmOffsetKick', propty_suffix='RB')
-        self._wfm_offset_sp = _PV(pvoffwfmsp)
-        self._wfm_offset_rb = _PV(pvoffwfmrb)
+        self._pvs['wfm_offset_sp'] = _PV(pvoffwfmsp)
+        self._pvs['wfm_offset_rb'] = _PV(pvoffwfmrb)
         self._config_ok_vals = {
             'OpMode': _PSConst.OpMode.SlowRef,
             'PwrState': _PSConst.PwrStateSel.On}
@@ -211,22 +200,13 @@ class CHCV(Corrector):
             pvobj.put(val, wait=False)
 
     @property
-    def connected(self):
-        """Status connected."""
-        conn = super().connected
-        conn &= self._ref.connected
-        if not self._ref.connected:
-            _log.debug("NOT CONN: " + self._ref.pvname)
-        return conn
-
-    @property
     def value(self):
         """Value."""
-        if not self._rb.connected:
+        if not self._pvs['rb'].connected:
             return None
         if self._config_ok_vals['OpMode'] == _PSConst.OpMode.RmpWfm:
             return self.wfm_offset_kick
-        return self._rb.value
+        return self._pvs['rb'].value
 
     @value.setter
     def value(self, val):
@@ -234,28 +214,28 @@ class CHCV(Corrector):
         if self._config_ok_vals['OpMode'] == _PSConst.OpMode.RmpWfm:
             self.wfm_offset_kick = val
         else:
-            self._sp.put(val, wait=False)
+            self._pvs['sp'].put(val, wait=False)
 
     @property
     def wfm_offset_kick(self):
         """."""
-        if not self._wfm_offset_rb.connected:
+        if not self._pvs['wfm_offset_rb'].connected:
             return None
-        return self._wfm_offset_rb.value
+        return self._pvs['wfm_offset_rb'].value
 
     @wfm_offset_kick.setter
     def wfm_offset_kick(self, val):
         """."""
-        self._wfm_offset_sp.put(val, wait=False)
+        self._pvs['wfm_offset_sp'].put(val, wait=False)
 
     @property
     def refvalue(self):
         """."""
-        if not self._ref.connected:
+        if not self._pvs['ref'].connected:
             return None
         if self._config_ok_vals['OpMode'] == _PSConst.OpMode.RmpWfm:
             return self.wfm_offset_kick
-        return self._ref.value
+        return self._pvs['ref'].value
 
     def configure(self):
         """Configure method."""
@@ -281,8 +261,8 @@ class Septum(Corrector):
             prefix=LL_PREF, propty_name="Kick", propty_suffix="SP"
         )
         pvrb = pvsp.substitute(propty_suffix="RB")
-        self._sp = _PV(pvsp, **opt)
-        self._rb = _PV(pvrb, **opt)
+        self._pvs['sp'] = _PV(pvsp, **opt)
+        self._pvs['rb'] = _PV(pvrb, **opt)
         self._nominalkick = 98.55  # mrad
         self._config_ok_vals = {
             "Pulse": 1,
@@ -322,8 +302,8 @@ class Septum(Corrector):
     @property
     def value(self):
         """Value."""
-        if self._rb.connected:
-            val = self._rb.value
+        if self._pvs['rb'].connected:
+            val = self._pvs['rb'].value
             if val is not None:
                 return -(val + self._nominalkick) * 1e3
 
@@ -331,7 +311,7 @@ class Septum(Corrector):
     def value(self, val):
         """."""
         val = val / 1e3 + self._nominalkick
-        self._sp.put(-val, wait=False)
+        self._pvs['sp'].put(-val, wait=False)
 
 
 def get_corr(name):
@@ -353,7 +333,7 @@ class TimingConfig(_BaseTimingConfig):
         pref_name = pref + self._csorb.evg_name + ":" + evt
         trig = self._csorb.trigger_cor_name
         opt = {"connection_timeout": TIMEOUT}
-        self._evt_sender = _PV(pref_name + "ExtTrig-Cmd", **opt)
+        self._pvs['evt_sender'] = _PV(pref_name + "ExtTrig-Cmd", **opt)
         src_val = self._csorb.CorrExtEvtSrc._fields.index(evt)
         src_val = self._csorb.CorrExtEvtSrc[src_val]
         self.EVT = src_val
@@ -411,7 +391,7 @@ class TimingConfig(_BaseTimingConfig):
 
     def send_evt(self):
         """Send event method."""
-        self._evt_sender.value = 1
+        self._pvs['evt_sender'].value = 1
 
     @property
     def state(self):
@@ -462,15 +442,6 @@ class TimingConfig(_BaseTimingConfig):
         if self.put_enable and pvobj.connected:
             pvobj.value = int(value)
 
-    @property
-    def connected(self):
-        """Status connected."""
-        conn = super().connected
-        conn &= self._evt_sender.connected
-        if not self._evt_sender.connected:
-            _log.debug("NOT CONN: " + self._evt_sender.pvname)
-        return conn
-
 
 class BaseCorrectors(_BaseClass):
     """Base correctors class."""
@@ -503,6 +474,16 @@ class EpicsCorrectors(BaseCorrectors):
         self._corrs_thread.start()
 
     @property
+    def connected(self):
+        """."""
+        for cor in self._corrs:
+            if not cor.connected:
+                return False
+        if not self.timing.connected:
+            return False
+        return True
+
+    @property
     def sofb(self):
         """."""
         return self._sofb
@@ -515,6 +496,18 @@ class EpicsCorrectors(BaseCorrectors):
     def corrs(self):
         """."""
         return self._corrs
+
+    def wait_for_connection(self, timeout=10):
+        """."""
+        t0_ = _time.time()
+        for cor in self._corrs:
+            tout = timeout - (_time.time() - t0_)
+            if tout <= 0 or not cor.wait_for_connection(tout):
+                return False
+        tout = timeout - (_time.time() - t0_)
+        if tout <= 0 or not self.timing.wait_for_connection(tout):
+            return False
+        return True
 
     def shutdown(self):
         """Shutdown threads."""

--- a/siriuspy/siriuspy/sofb/csdev.py
+++ b/siriuspy/siriuspy/sofb/csdev.py
@@ -76,7 +76,7 @@ class ConstTLines(_csdev.Const):
     TINY_KICK = 1e-3  # [urad]
     DEF_MAX_ORB_DISTORTION = 50  # [um]
     ACQRATE_TRIGMODE = 2  # [Hz]
-    ACQRATE_SLOWORB = 60  # [Hz]
+    ORBIT_UPDATE_RATE = 60  # [Hz] very high frequency to improve sinc.
     BPMsFreq = 10.48  # [Hz]
 
     TrigAcqCtrl = _CSBPM.AcqEvents

--- a/siriuspy/siriuspy/sofb/main.py
+++ b/siriuspy/siriuspy/sofb/main.py
@@ -87,6 +87,43 @@ class SOFB(_BaseClass):
             for i in range(1, 21)
         ]
 
+    @property
+    def connected(self):
+        """."""
+        if self.acc == 'SI' and not self.fofb.connected:
+            return False
+        for acm in self._acms:
+            if not acm.connected:
+                return False
+        if not self._havebeam_pv.connected:
+            return False
+        if self._orbit is not None and not self._orbit.connected:
+            return False
+        if self._correctors is not None and not self._correctors.connected:
+            return False
+        return True
+
+    def wait_for_connection(self, timeout=10):
+        """."""
+        t0_ = _time()
+        tout = timeout
+        if self.acc == 'SI' and not self.fofb.wait_for_connection(tout):
+            return False
+        for amc in self._amcs:
+            tout = timeout - (_time() - t0_)
+            if tout <= 0 or not amc.wait_for_connection(tout):
+                return False
+        tout = timeout - (_time() - t0_)
+        if tout <= 0 or not self._havebeam_pv.wait_for_connection(tout):
+            return False
+        for dev in [self._orbit, self._correctors]:
+            if dev is None:
+                continue
+            tout = timeout - (_time() - t0_)
+            if tout <= 0 or not dev.wait_for_connection(tout):
+                return False
+        return True
+
     def get_map2write(self):
         """Get the database of the class."""
         dbase = {

--- a/siriuspy/siriuspy/sofb/orbit.py
+++ b/siriuspy/siriuspy/sofb/orbit.py
@@ -24,7 +24,7 @@ class BaseOrbit(_BaseClass):
 class EpicsOrbit(BaseOrbit):
     """Class to deal with orbit acquisition."""
 
-    TIMEOUT_TRIG_ACQ = 1 / 2  # [s] time between injections
+    TIMEOUT_TRIG_ACQ = 1 / 2 - 0.05  # [s] a little faster than injection freq.
 
     def __init__(self, acc, prefix="", callback=None):
         """Initialize the instance."""


### PR DESCRIPTION
This change will decrease archiver load, since triggered orbits will only update when all BPMs have updated.

I also removed @murilobalves from the CODEOWNERS file so that he is not included automatically, because, differently from what I thought, we cannot remove him from the reviewers list before creating the PR, which means he would continue to receive notifications for every PR.