### PR TITLE
Improve SOFB-SOFB interplay

### DIFF
--- a/siriuspy/siriuspy/clientconfigdb/types/as_corrloop_params.py
+++ b/siriuspy/siriuspy/clientconfigdb/types/as_corrloop_params.py
@@ -230,8 +230,6 @@ _si_sofb = [
     ['SI-Glob:AP-SOFB:CorrPSSOFBEnbl-Sel', 0, 0.0],
     ['SI-Glob:AP-SOFB:FOFBDownloadKicks-Sel', 0, 0.0],
     ['SI-Glob:AP-SOFB:FOFBUpdateRefOrb-Sel', 0, 0.0],
-    ['SI-Glob:AP-SOFB:FOFBNullSpaceProj-Sel', 0, 0.0],
-    ['SI-Glob:AP-SOFB:FOFBZeroDistortionAtBPMs-Sel', 0, 0.0],
     ['SI-Glob:AP-SOFB:FOFBDownloadKicksPerc-SP', 0, 0.0],
     ['SI-Glob:AP-SOFB:FOFBUpdateRefOrbPerc-SP', 0, 0.0],
     ['SI-Glob:AP-SOFB:FOFBUpdateRefOrbRate-SP', 0, 0],

--- a/siriuspy/siriuspy/clientconfigdb/types/as_corrloop_params.py
+++ b/siriuspy/siriuspy/clientconfigdb/types/as_corrloop_params.py
@@ -234,6 +234,7 @@ _si_sofb = [
     ['SI-Glob:AP-SOFB:FOFBZeroDistortionAtBPMs-Sel', 0, 0.0],
     ['SI-Glob:AP-SOFB:FOFBDownloadKicksPerc-SP', 0, 0.0],
     ['SI-Glob:AP-SOFB:FOFBUpdateRefOrbPerc-SP', 0, 0.0],
+    ['SI-Glob:AP-SOFB:FOFBUpdateRefOrbRate-SP', 0, 0],
     ['SI-Glob:AP-SOFB:RespMat-SP', [0.0, ]*449600, 0.0],
     ['SI-Glob:AP-SOFB:RespMatMode-Sel', 0, 0.0],
     ['SI-Glob:AP-SOFB:BPMXEnblList-SP', [0, ]*800, 0.0],

--- a/siriuspy/siriuspy/sofb/csdev.py
+++ b/siriuspy/siriuspy/sofb/csdev.py
@@ -1179,7 +1179,7 @@ class SOFBSI(SOFBRings, ConstSI):
                 'type': 'enum', 'value': self.DsblEnbl.Enbl,
                 'enums': self.DsblEnbl._fields},
             'FOFBDownloadKicks-Mon': {
-                'type': 'enum', 'value': self.DsblEnbl.Enbl,
+                'type': 'enum', 'value': self.DsblEnbl.Dsbl,
                 'enums': self.DsblEnbl._fields},
             'FOFBDownloadKicksCH-Mon': {
                 'type': 'float',
@@ -1211,10 +1211,10 @@ class SOFBSI(SOFBRings, ConstSI):
                 'type': 'float', 'value': 100.0, 'prec': 2, 'unit': '%',
                 'lolim': -0.1, 'hilim': 100.1},
             'FOFBUpdateRefOrb-Sel': {
-                'type': 'enum', 'value': self.DsblEnbl.Dsbl,
+                'type': 'enum', 'value': self.DsblEnbl.Enbl,
                 'enums': self.DsblEnbl._fields},
             'FOFBUpdateRefOrb-Sts': {
-                'type': 'enum', 'value': self.DsblEnbl.Dsbl,
+                'type': 'enum', 'value': self.DsblEnbl.Enbl,
                 'enums': self.DsblEnbl._fields},
             'FOFBUpdateRefOrb-Mon': {
                 'type': 'enum', 'value': self.DsblEnbl.Dsbl,

--- a/siriuspy/siriuspy/sofb/csdev.py
+++ b/siriuspy/siriuspy/sofb/csdev.py
@@ -1205,11 +1205,11 @@ class SOFBSI(SOFBRings, ConstSI):
                 'lolim': 1, 'hilim': 100,
             },
             'FOFBUpdateRefOrbPerc-SP': {
-                'type': 'float', 'value': 0.0, 'prec': 2, 'unit': '%',
-                'lolim': -100.1, 'hilim': 100.1},
+                'type': 'float', 'value': 100.0, 'prec': 2, 'unit': '%',
+                'lolim': -0.1, 'hilim': 100.1},
             'FOFBUpdateRefOrbPerc-RB': {
-                'type': 'float', 'value': 0.0, 'prec': 2, 'unit': '%',
-                'lolim': -100.1, 'hilim': 100.1},
+                'type': 'float', 'value': 100.0, 'prec': 2, 'unit': '%',
+                'lolim': -0.1, 'hilim': 100.1},
             'FOFBUpdateRefOrb-Sel': {
                 'type': 'enum', 'value': self.DsblEnbl.Dsbl,
                 'enums': self.DsblEnbl._fields},
@@ -1337,6 +1337,8 @@ class SOFBSI(SOFBRings, ConstSI):
             }
         )
         dbase = super().get_orbit_database(prefix=prefix)
+        dbase["SmoothNrPts-SP"]['value'] = 20
+        dbase["SmoothNrPts-RB"]['value'] = 20
         dbase.update(self._add_prefix(db_ring, prefix))
         return dbase
 

--- a/siriuspy/siriuspy/sofb/csdev.py
+++ b/siriuspy/siriuspy/sofb/csdev.py
@@ -1231,24 +1231,6 @@ class SOFBSI(SOFBRings, ConstSI):
                 'count': self.nr_bpms,
                 'value': self.nr_bpms*[0],
             },
-            'FOFBNullSpaceProj-Sel': {
-                'type': 'enum', 'value': self.DsblEnbl.Dsbl,
-                'enums': self.DsblEnbl._fields},
-            'FOFBNullSpaceProj-Sts': {
-                'type': 'enum', 'value': self.DsblEnbl.Dsbl,
-                'enums': self.DsblEnbl._fields},
-            'FOFBNullSpaceProj-Mon': {
-                'type': 'enum', 'value': self.DsblEnbl.Dsbl,
-                'enums': self.DsblEnbl._fields},
-            'FOFBZeroDistortionAtBPMs-Sel': {
-                'type': 'enum', 'value': self.DsblEnbl.Dsbl,
-                'enums': self.DsblEnbl._fields},
-            'FOFBZeroDistortionAtBPMs-Sts': {
-                'type': 'enum', 'value': self.DsblEnbl.Dsbl,
-                'enums': self.DsblEnbl._fields},
-            'FOFBZeroDistortionAtBPMs-Mon': {
-                'type': 'enum', 'value': self.DsblEnbl.Dsbl,
-                'enums': self.DsblEnbl._fields},
             'DriveFreqDivisor-SP': {
                 'type': 'int', 'value': 12, 'unit': 'Div',
                 'lolim': 0, 'hilim': 1000},

--- a/siriuspy/siriuspy/sofb/csdev.py
+++ b/siriuspy/siriuspy/sofb/csdev.py
@@ -1196,6 +1196,14 @@ class SOFBSI(SOFBRings, ConstSI):
             'FOFBDownloadKicksRF-Mon': {
                 'type': 'float', 'value': 0, 'prec': 3, 'unit': 'Hz',
             },
+            'FOFBUpdateRefOrbRate-SP': {
+                'type': 'int', 'value': 3, 'unit': 'LoopFreqDiv',
+                'lolim': 1, 'hilim': 100,
+            },
+            'FOFBUpdateRefOrbRate-RB': {
+                'type': 'int', 'value': 3, 'unit': 'LoopFreqDiv',
+                'lolim': 1, 'hilim': 100,
+            },
             'FOFBUpdateRefOrbPerc-SP': {
                 'type': 'float', 'value': 0.0, 'prec': 2, 'unit': '%',
                 'lolim': -100.1, 'hilim': 100.1},

--- a/siriuspy/siriuspy/sofb/main.py
+++ b/siriuspy/siriuspy/sofb/main.py
@@ -332,6 +332,7 @@ class SOFB(_BaseClass):
         value = min(max(int(value), 1), 100)
         self._update_fofb_reforb_rate = value
         self.run_callbacks("FOFBUpdateRefOrbRate-RB", value)
+        return True
 
     def apply_corr(self, code):
         """Apply calculated kicks on the correctors."""
@@ -1105,8 +1106,8 @@ class SOFB(_BaseClass):
                 # https://accelconf.web.cern.ch/d09/papers/mooc01.pdf
                 # https://accelconf.web.cern.ch/d09/talks/mooc01_talk.pdf
                 # this is what they do there:
-                fofb.refx -= dorb[:dorb.size // 2]
-                fofb.refy -= dorb[dorb.size // 2:]
+                fofb.refx = fofb.refx + dorb[:dorb.size // 2]
+                fofb.refy = fofb.refy + dorb[dorb.size // 2:]
                 fofb.cmd_fofbctrl_syncreforb()
                 self._LQTHREAD.put((self._update_fofb_dorb, (dorb, )))
 

--- a/siriuspy/siriuspy/sofb/main.py
+++ b/siriuspy/siriuspy/sofb/main.py
@@ -62,7 +62,7 @@ class SOFB(_BaseClass):
             self._download_fofb_kicks = True
             self._download_fofb_kicks_perc = 0.40
             self._update_fofb_reforb = False
-            self._update_fofb_reforb_perc = 0.0
+            self._update_fofb_reforb_perc = 100.0
             self._update_fofb_reforb_iter = 0
             self._update_fofb_reforb_rate = 3  # every n SOFB iterations
             self._drive_divisor = 12
@@ -318,7 +318,7 @@ class SOFB(_BaseClass):
             bool: Whether property was set.
 
         """
-        value = min(max(value / 100, -1), 1)
+        value = min(max(value / 100, -0.1), 1)
         self._update_fofb_reforb_perc = value
         self.run_callbacks("FOFBUpdateRefOrbPerc-RB", value * 100)
         return True

--- a/siriuspy/siriuspy/sofb/main.py
+++ b/siriuspy/siriuspy/sofb/main.py
@@ -61,7 +61,7 @@ class SOFB(_BaseClass):
             self.fofb = HLFOFB()
             self._download_fofb_kicks = True
             self._download_fofb_kicks_perc = 0.40
-            self._update_fofb_reforb = False
+            self._update_fofb_reforb = True
             self._update_fofb_reforb_perc = 100.0
             self._update_fofb_reforb_iter = 0
             self._update_fofb_reforb_rate = 3  # every n SOFB iterations

--- a/siriuspy/siriuspy/sofb/orbit.py
+++ b/siriuspy/siriuspy/sofb/orbit.py
@@ -65,6 +65,7 @@ class EpicsOrbit(BaseOrbit):
                 callback=self._update_sloworb_raw,
                 auto_monitor=True,
             )
+            self._smooth_npts = 20
         self._timestamp_last_news = 0  # [s] timestamp in epoch
         self._last_num_news = 0
         self._orbit_thread = _Repeat(
@@ -730,7 +731,7 @@ class EpicsOrbit(BaseOrbit):
             with self._lock_raw_orbs:
                 raws = self.raw_orbs
                 raws[plane].append(orbs[plane])
-                raws[plane] = raws[plane][-self._smooth_npts :]
+                raws[plane] = raws[plane][-self._smooth_npts:]
                 if not raws[plane]:
                     return
                 if self._smooth_meth == self._csorb.SmoothMeth.Average:


### PR DESCRIPTION
This PR improves the interplay of both systems by adding a PV to control the rate of FOFB reference orbit update when both loops are closed. It was already tested with beam, where it was noted that updating the FOFB reference orbit always leads to zero DC kicks on FOFB correctors and on delta kicks of the slow correctors.

Today, when some BPM of the FOFB loop has a non-zero value in some orbit signature that is on the null-space of the SOFB response matrix, the FOFB tries to correct this distortion, which makes the resulting orbit not to be on the null-space of the SOFB loop. This makes SOFB try to correct this projection, trying to recover the null-space residue again. When this happens, the loops do not aggree on which state should be the correct one, leading to a non-zero DC strength on FOFB correctors and on SOFB delta kicks.

With the reference orbit update, SOFB tells FOFB not to worry with that BPM deviation, and the latter ends up correcting the orbit to the SOFB null-space orbit residue.
The down side of this effect is that the orbit is not exactly corrected to the ideal reference orbit anymore at the BPMs on the FOFB loop.

I also removed some unused PVs to control the interaction between both systems.

to be merged after #1188.