### PR TITLE
DEP: (DEV.SCRN) Remove TB-04:DI-Scrn from device

### DIFF
--- a/siriuspy/siriuspy/devices/screen.py
+++ b/siriuspy/siriuspy/devices/screen.py
@@ -12,6 +12,7 @@ class Screen(_DeviceSet):
 
     class DEVICES:
         """Devices names."""
+
         # NOTE: TB-04:DI-Scrn was removed during 2026-03 shutdown due to
         # Septum activities aimed at avoiding secondary current
         # loops from its pulsed field.

--- a/siriuspy/siriuspy/devices/screen.py
+++ b/siriuspy/siriuspy/devices/screen.py
@@ -36,7 +36,7 @@ class Screen(_DeviceSet):
         LI_4 = 'LA-BI:PRF4'
         LI_5 = 'LA-BI:PRF5'
         LI = (LI_1, LI_2, LI_3, LI_4, LI_5)
-        TB = (TB_1, TB_2, TB_3, TB_4, TB_5, TB_6)
+        TB = (TB_1, TB_2, TB_3, TB_4, TB_5)
         BO = (BO_1, BO_2, BO_3)
         TS = (TS_1, TS_2, TS_3, TS_4, TS_5, TS_6)
         ALL = TB + BO + TS + LI

--- a/siriuspy/siriuspy/devices/screen.py
+++ b/siriuspy/siriuspy/devices/screen.py
@@ -1,6 +1,7 @@
 """."""
 
 from mathphys.functions import get_namedtuple as _get_namedtuple
+from siriuspy.siriuspy.sofb.correctors import Septum
 
 from ..namesys import SiriusPVName as _PVName
 from .device import Device as _Device, DeviceSet as _DeviceSet
@@ -11,13 +12,15 @@ class Screen(_DeviceSet):
 
     class DEVICES:
         """Devices names."""
-
+        # NOTE: TB-04:DI-Scrn was removed during 2026-03 shutdown due to
+        # Septum activities aimed at avoiding secondary current
+        # loops from its pulsed field.
         TB_1 = 'TB-01:DI-Scrn-1'
         TB_2 = 'TB-01:DI-Scrn-2'
         TB_3 = 'TB-02:DI-Scrn-1'
         TB_4 = 'TB-02:DI-Scrn-2'
         TB_5 = 'TB-03:DI-Scrn'
-        TB_6 = 'TB-04:DI-Scrn'
+        # TB_6 = 'TB-04:DI-Scrn'
         BO_1 = 'BO-01D:DI-Scrn-1'
         BO_2 = 'BO-01D:DI-Scrn-2'
         BO_3 = 'BO-02U:DI-Scrn'

--- a/siriuspy/siriuspy/devices/screen.py
+++ b/siriuspy/siriuspy/devices/screen.py
@@ -11,6 +11,7 @@ class Screen(_DeviceSet):
 
     class DEVICES:
         """Devices names."""
+
         TB_1 = 'TB-01:DI-Scrn-1'
         TB_2 = 'TB-01:DI-Scrn-2'
         TB_3 = 'TB-02:DI-Scrn-1'

--- a/siriuspy/siriuspy/devices/screen.py
+++ b/siriuspy/siriuspy/devices/screen.py
@@ -12,9 +12,9 @@ class Screen(_DeviceSet):
     class DEVICES:
         """Devices names."""
 
-        # NOTE: TB-04:DI-Scrn was removed during 2026-03 shutdown due to
-        # Septum activities aimed at avoiding secondary current
-        # loops from its pulsed field.
+        # NOTE: TB-04:DI-Scrn was removed during the March 2026 shutdown
+        # as part of septum-related modifications to mitigate
+        # secondary current loops induced by its pulsed field.
         TB_1 = 'TB-01:DI-Scrn-1'
         TB_2 = 'TB-01:DI-Scrn-2'
         TB_3 = 'TB-02:DI-Scrn-1'

--- a/siriuspy/siriuspy/devices/screen.py
+++ b/siriuspy/siriuspy/devices/screen.py
@@ -11,16 +11,11 @@ class Screen(_DeviceSet):
 
     class DEVICES:
         """Devices names."""
-
-        # NOTE: TB-04:DI-Scrn was removed during the March 2026 shutdown
-        # as part of septum-related modifications to mitigate
-        # secondary current loops induced by its pulsed field.
         TB_1 = 'TB-01:DI-Scrn-1'
         TB_2 = 'TB-01:DI-Scrn-2'
         TB_3 = 'TB-02:DI-Scrn-1'
         TB_4 = 'TB-02:DI-Scrn-2'
         TB_5 = 'TB-03:DI-Scrn'
-        # TB_6 = 'TB-04:DI-Scrn'
         BO_1 = 'BO-01D:DI-Scrn-1'
         BO_2 = 'BO-01D:DI-Scrn-2'
         BO_3 = 'BO-02U:DI-Scrn'

--- a/siriuspy/siriuspy/devices/screen.py
+++ b/siriuspy/siriuspy/devices/screen.py
@@ -1,7 +1,6 @@
 """."""
 
 from mathphys.functions import get_namedtuple as _get_namedtuple
-from siriuspy.siriuspy.sofb.correctors import Septum
 
 from ..namesys import SiriusPVName as _PVName
 from .device import Device as _Device, DeviceSet as _DeviceSet


### PR DESCRIPTION
TB-04:DI-Scrn was removed during the March 2026 shutdown as part of septum-related modifications to mitigate secondary current loops induced by its pulsed field.